### PR TITLE
ci: add build and test workflows

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -1,0 +1,61 @@
+# Copyright © 2022 Kubernetes Authors
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Build and Test
+on:
+  push:
+    branches:
+    - "main"
+    - "release/v*"
+    paths-ignore:
+    - "**/*.png"
+  pull_request:
+    branches:
+    - "main"
+    - "release/v*"
+    paths-ignore:
+    - "**/*.png"
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: ./tools/github-actions/setup-deps
+    - run: make lint-deps
+    - run: make -k lint
+
+  coverage-test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: ./tools/github-actions/setup-deps
+
+    - name: Run Coverage Tests
+      run: make go.test.coverage
+
+  build:
+    runs-on: ubuntu-latest
+    needs: [lint, coverage-test]
+    steps:
+    - uses: actions/checkout@v3
+    - uses: ./tools/github-actions/setup-deps
+
+    - name: Build i2gw Multiarch Binaries
+      run: make build-multiarch PLATFORMS="linux_amd64 linux_arm64"
+
+    - name: Upload ingress2gateway Binaries
+      uses: actions/upload-artifact@v3
+      with:
+        name: i2gw
+        path: _output/


### PR DESCRIPTION
**What type of PR is this?**
<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test

-->


**What this PR does / why we need it**:

- [ ] Build and Test Workflow: 
  - [ ] runs test: unit test, e2e test(TODO) of i2gw.
  - [ ] runs linters: golint, yamllint, codespells.
  - [ ] runs multi-arch build of i2gw.

Sub of #9

**Which issue(s) this PR fixes**:

xref: #21

**Does this PR introduce a user-facing change?**:

```release-note

```
