### PR TITLE
ci: add auto release workflows

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,52 @@
+# Copyright © 2022 Kubernetes Authors
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Release
+
+on:
+  push:
+    # Sequence of patterns matched against refs/tags
+    tags:        
+      - "v*.*.*"
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Extract Release Tag and Commit SHA
+        id: vars
+        shell: bash
+        run: |
+          echo "release_tag=$(echo ${GITHUB_REF##*/})" >> $GITHUB_ENV
+          echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+
+      - name: Build the i2gw release multiarch binaries
+        run: | 
+          make build-multiarch
+          tar -zcvf i2gw_latest_linux_amd64.tar.gz _output/linux/amd64/
+          tar -zcvf i2gw_latest_linux_arm64.tar.gz _output/linux/arm64/
+          tar -zcvf i2gw_latest_darwin_amd64.tar.gz _output/darwin/amd64/
+          tar -zcvf i2gw_latest_darwin_arm64.tar.gz _output/darwin/arm64/
+
+      - name: Release the i2gw release multiarch binaries
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            i2gw_latest_linux_amd64.tar.gz
+            i2gw_latest_linux_arm64.tar.gz
+            i2gw_latest_darwin_amd64.tar.gz
+            i2gw_latest_darwin_arm64.tar.gz
+          body: |
+            This is the ${{ env.release_tag }} release of **Ingress2Gateway**.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,4 @@
-# Copyright © 2022 Kubernetes Authors
+# Copyright © 2023 Kubernetes Authors
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
**What type of PR is this?**
<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test

-->


**What this PR does / why we need it**:

Sub of #9

**Which issue(s) this PR fixes**:

- [ ] Release Workflow: 
  - [ ] support automatcally build and publish i2gw multi-arch binaries when pushing a new tag.

**Does this PR introduce a user-facing change?**:

```release-note

```
