### PR TITLE
Add support for resource filtering by namespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,4 +50,4 @@ build: vet;$(info $(M)...Build the binary.)  @ ## Build the binary.
 # Run static analysis.
 .PHONY: verify
 verify:
-	hack/verify-all.sh
+	hack/verify-all.sh -v

--- a/cmd/print.go
+++ b/cmd/print.go
@@ -23,12 +23,23 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/printers"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 var (
 	// outputFormat contains currently set output format. Value assigned via --output/-o flag.
 	// Defaults to YAML.
 	outputFormat = "yaml"
+
+	// namespace contains currently set namespace that should be used. Value assigned via
+	// --namespace/-n flag.
+	// Default behavior is to use the current namespace the user is in.
+	namespace string
+
+	// allNamespaces indicates whether all namespaces should be used. Value assigned via
+	// --all-namespaces/-A flag.
+	// If present, overrides the namespace variable.
+	allNamespaces bool
 )
 
 // printCmd represents the print command. It prints HTTPRoutes and Gateways
@@ -41,7 +52,11 @@ var printCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		i2gw.Run(resourcePrinter)
+		namespaceFilter, err := getNamespaceFilter(namespace, allNamespaces)
+		if err != nil {
+			return err
+		}
+		i2gw.Run(resourcePrinter, namespaceFilter)
 		return nil
 	},
 }
@@ -59,12 +74,46 @@ func getResourcePrinter(outputFormat string) (printers.ResourcePrinter, error) {
 	}
 }
 
+// getNamespaceFilter returns a namespace filter, taking into consideration whether a specific
+// namespace is requested, or all of them are.
+func getNamespaceFilter(requestedNamespace string, useAllNamespaces bool) (string, error) {
+
+	// When we should use all namespaces, return an empty string.
+	// This is the first condition since it should override the requestedNamespace,
+	// if specified.
+	if useAllNamespaces {
+		return "", nil
+	}
+
+	if requestedNamespace == "" {
+		return getNamespaceInCurrentContext()
+	}
+	return requestedNamespace, nil
+}
+
+// getNamespaceInCurrentContext returns the namespace in the current active context of the user.
+func getNamespaceInCurrentContext() (string, error) {
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+
+	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, &clientcmd.ConfigOverrides{})
+	currentNamespace, _, err := kubeConfig.Namespace()
+
+	return currentNamespace, err
+}
+
 func init() {
 	var printFlags genericclioptions.JSONYamlPrintFlags
 	allowedFormats := printFlags.AllowedFormats()
 
 	printCmd.Flags().StringVarP(&outputFormat, "output", "o", "yaml",
 		fmt.Sprintf(`Output format. One of: (%s)`, strings.Join(allowedFormats, ", ")))
+
+	printCmd.Flags().StringVarP(&namespace, "namespace", "n", "",
+		fmt.Sprintf(`If present, the namespace scope for this CLI request`))
+
+	printCmd.Flags().BoolVarP(&allNamespaces, "all-namespaces", "A", false,
+		fmt.Sprintf(`If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even
+if specified with --namespace.`))
 
 	rootCmd.AddCommand(printCmd)
 }

--- a/cmd/print.go
+++ b/cmd/print.go
@@ -31,14 +31,13 @@ var (
 	// Defaults to YAML.
 	outputFormat = "yaml"
 
-	// namespace contains currently set namespace that should be used. Value assigned via
+	// The namespace used to query Gateway API objects. Value assigned via
 	// --namespace/-n flag.
-	// Default behavior is to use the current namespace the user is in.
+	// On absence, the current user active namespace is used.
 	namespace string
 
 	// allNamespaces indicates whether all namespaces should be used. Value assigned via
 	// --all-namespaces/-A flag.
-	// If present, overrides the namespace variable.
 	allNamespaces bool
 )
 

--- a/cmd/print.go
+++ b/cmd/print.go
@@ -114,5 +114,7 @@ func init() {
 		fmt.Sprintf(`If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even
 if specified with --namespace.`))
 
+	printCmd.MarkFlagsMutuallyExclusive("namespace", "all-namespaces")
+
 	rootCmd.AddCommand(printCmd)
 }

--- a/cmd/print_test.go
+++ b/cmd/print_test.go
@@ -16,6 +16,7 @@ limitations under the License.
 package cmd
 
 import (
+	"os"
 	"reflect"
 	"testing"
 
@@ -71,5 +72,142 @@ func Test_getResourcePrinter(t *testing.T) {
 			}
 		})
 
+	}
+}
+
+func Test_getNamespaceFilter(t *testing.T) {
+	testCases := []struct {
+		name                      string
+		namespace                 string
+		allNamespaces             bool
+		expectedNamespaceFilter   string
+		expectingError            bool
+		expectingCurrentNamespace bool
+	}{
+		{
+			name:                      "Only namespace is specified",
+			namespace:                 "default",
+			allNamespaces:             false,
+			expectedNamespaceFilter:   "default",
+			expectingError:            false,
+			expectingCurrentNamespace: false,
+		},
+		{
+			name:                      "All namespaces overrides a specific namespace",
+			namespace:                 "default",
+			allNamespaces:             true,
+			expectedNamespaceFilter:   "",
+			expectingError:            false,
+			expectingCurrentNamespace: false,
+		},
+		{
+			name:                      "Current namespace used when nothing specified",
+			namespace:                 "",
+			allNamespaces:             false,
+			expectedNamespaceFilter:   "_",
+			expectingError:            false,
+			expectingCurrentNamespace: true,
+		},
+	}
+
+	destroy, err := setupKubeConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer destroy()
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualNamespaceFilter, err := getNamespaceFilter(tc.namespace, tc.allNamespaces)
+
+			if tc.expectingError && err == nil {
+				t.Errorf("Expected error but got none")
+			}
+			if !tc.expectingError && err != nil {
+				t.Errorf("Expected no error but got %v", err)
+			}
+
+			if tc.expectingCurrentNamespace {
+				tc.expectedNamespaceFilter, _ = getNamespaceFilter(tc.namespace, tc.allNamespaces)
+			}
+
+			if actualNamespaceFilter != tc.expectedNamespaceFilter {
+				t.Errorf(`getNamespaceFilter("%s", %v) = %v, expected %v`,
+					tc.namespace, tc.allNamespaces, actualNamespaceFilter, tc.expectedNamespaceFilter)
+			}
+		})
+
+	}
+}
+
+func setupKubeConfig() (func(), error) {
+	const kubeConfigFile = "/tmp/i2gw/.kube/config"
+
+	if err := os.Setenv("KUBECONFIG", kubeConfigFile); err != nil {
+		return nil, err
+	}
+
+	// Clean up from the last test, just in case...
+	os.Remove(kubeConfigFile)
+
+	content := []byte(`
+apiVersion: v1
+clusters:
+- cluster:
+    server: https://kubernetes.docker.internal:6443
+  name: docker-desktop
+- cluster:
+    server: https://127.0.0.1:54873
+  name: kind-i2gw
+contexts:
+- context:
+    cluster: docker-desktop
+    namespace: non-default-ns
+    user: docker-desktop
+  name: docker-desktop
+- context:
+    cluster: kind-i2gw
+    user: kind-i2gw
+  name: kind-i2gw
+current-context: docker-desktop
+kind: Config
+preferences: {}
+`)
+
+	f, err := os.Create(kubeConfigFile)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err = f.Write(content); err != nil {
+		os.Remove(kubeConfigFile)
+		return nil, err
+	}
+	if err = f.Close(); err != nil {
+		os.Remove(kubeConfigFile)
+		return nil, err
+	}
+
+	return func() {
+		os.Remove(kubeConfigFile)
+	}, nil
+}
+
+func Test_getNamespaceInCurrentContext(t *testing.T) {
+	destroy, err := setupKubeConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer destroy()
+
+	expectedNamespace := "non-default-ns" // according to the kube-config at setupKubeConfig()
+	actualNamespace, err := getNamespaceInCurrentContext()
+	if err != nil {
+		t.Fatalf("Expected no error but got %v", err)
+	}
+
+	if expectedNamespace != actualNamespace {
+		t.Errorf(`getNamespaceInCurrentContext() = "%s", %v, expected %s, %v`,
+			actualNamespace, err, expectedNamespace, nil)
 	}
 }

--- a/cmd/print_test.go
+++ b/cmd/print_test.go
@@ -16,6 +16,8 @@ limitations under the License.
 package cmd
 
 import (
+	"fmt"
+	"log"
 	"os"
 	"reflect"
 	"testing"
@@ -141,7 +143,8 @@ func Test_getNamespaceFilter(t *testing.T) {
 }
 
 func setupKubeConfig() (func(), error) {
-	const kubeConfigFile = "/tmp/i2gw/.kube/config"
+	const kubeConfigPath = "/tmp/i2gw/.kube"
+	kubeConfigFile := fmt.Sprintf("%s/config", kubeConfigPath)
 
 	if err := os.Setenv("KUBECONFIG", kubeConfigFile); err != nil {
 		return nil, err
@@ -173,6 +176,11 @@ current-context: docker-desktop
 kind: Config
 preferences: {}
 `)
+
+	err := os.MkdirAll(kubeConfigPath, os.ModePerm)
+	if err != nil {
+		log.Println(err)
+	}
 
 	f, err := os.Create(kubeConfigFile)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	k8s.io/api v0.25.2
 	k8s.io/apimachinery v0.25.2
 	k8s.io/cli-runtime v0.25.2
+	k8s.io/client-go v0.25.2
 	sigs.k8s.io/controller-runtime v0.13.0
 	sigs.k8s.io/gateway-api v0.5.0
 )
@@ -58,7 +59,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/client-go v0.25.2 // indirect
 	k8s.io/klog/v2 v2.70.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20220803162953-67bda5d908f1 // indirect
 	k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed // indirect

--- a/pkg/i2gw/ingress2gateway.go
+++ b/pkg/i2gw/ingress2gateway.go
@@ -50,11 +50,12 @@ func Run(printer printers.ResourcePrinter, namespace string) {
 	}
 
 	if len(ingressList.Items) == 0 {
-		str := "No resources found"
+		msg := "No resources found"
 		if namespace != "" {
-			str += fmt.Sprintf(" in %s namespace.", namespace)
+			fmt.Printf("%s in %s namespace", msg, namespace)
+		} else {
+		        fmt.Println(msg)
 		}
-		fmt.Println(str)
 		return
 	}
 

--- a/pkg/i2gw/ingress2gateway.go
+++ b/pkg/i2gw/ingress2gateway.go
@@ -52,9 +52,9 @@ func Run(printer printers.ResourcePrinter, namespace string) {
 	if len(ingressList.Items) == 0 {
 		msg := "No resources found"
 		if namespace != "" {
-			fmt.Printf("%s in %s namespace", msg, namespace)
+			fmt.Printf("%s in %s namespace\n", msg, namespace)
 		} else {
-		        fmt.Println(msg)
+			fmt.Println(msg)
 		}
 		return
 	}


### PR DESCRIPTION
**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature
**What this PR does / why we need it**:
This PR introduces 2 new flags which will enable the user to filter Gateway API objects by namespace.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #30 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Add a --namespace / -n flag to support Gateway API object filtering by namespace.
In addition, a --all-namespaces / -A flag to indicate that all namespaces should be used.
The current namespace will be used if none of the flags is specified.
```
