### PR TITLE
Refactor print.go and ingress2gateway.go

### DIFF
--- a/cmd/print.go
+++ b/cmd/print.go
@@ -65,7 +65,6 @@ var printCmd = &cobra.Command{
 		// If the input file is specified, and we failed to get the namespace, use all namespaces.
 		i2gw.Run(resourcePrinter, namespaceFilter, inputFile)
 		return nil
-		return err
 	},
 }
 

--- a/cmd/print.go
+++ b/cmd/print.go
@@ -27,10 +27,10 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-var (
+type PrintRunner struct {
 	// outputFormat contains currently set output format. Value assigned via --output/-o flag.
 	// Defaults to YAML.
-	outputFormat = "yaml"
+	outputFormat string
 
 	// The path to the input yaml config file. Value assigned via --input_file flag
 	inputFile string
@@ -43,59 +43,112 @@ var (
 	// allNamespaces indicates whether all namespaces should be used. Value assigned via
 	// --all-namespaces/-A flag.
 	allNamespaces bool
-)
 
-// printCmd represents the print command. It prints HTTPRoutes and Gateways
-// generated from Ingress resources.
-var printCmd = &cobra.Command{
-	Use:   "print",
-	Short: "Prints HTTPRoutes and Gateways generated from Ingress resources",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		resourcePrinter, err := getResourcePrinter(outputFormat)
-		if err != nil {
-			return err
-		}
-		namespaceFilter, err := getNamespaceFilter(namespace, allNamespaces)
-		if err != nil && inputFile == "" {
+	// resourcePrinter determines how resource objects are printed out
+	resourcePrinter printers.ResourcePrinter
+
+	// Only resources that matches this filter will be processed.
+	namespaceFilter string
+}
+
+func NewDefaultPrintRunner() *PrintRunner {
+	pr := &PrintRunner{}
+	pr.outputFormat = "yaml"
+	return pr
+}
+
+func (pr *PrintRunner) PrintGatewaysAndHttpRoutes(cmd *cobra.Command, args []string) error {
+	i2gw.Run(pr.resourcePrinter, pr.namespaceFilter, pr.inputFile)
+	return nil
+}
+
+// InitializeResourcePrinter assign a specific type of printers.ResourcePrinter
+// based on the outputFormat of the printRunner struct.
+func (pr *PrintRunner) InitializeResourcePrinter() error {
+	switch pr.outputFormat {
+	case "yaml", "":
+		pr.resourcePrinter = &printers.YAMLPrinter{}
+		return nil
+	case "json":
+		pr.resourcePrinter = &printers.JSONPrinter{}
+		return nil
+	default:
+		return fmt.Errorf("%s is not a supported output format", pr.outputFormat)
+	}
+
+}
+
+func (pr *PrintRunner) InitializeNamespaceFilter() error {
+	// When we should use all namespaces, empty string is used as the filter.
+	if pr.allNamespaces {
+		pr.namespaceFilter = ""
+		return nil
+	}
+
+	if pr.namespace == "" {
+		ns, err := getNamespaceInCurrentContext()
+		if err != nil && pr.inputFile == "" {
 			// When asked to read from the cluster, but getting the current namespace
 			// failed for whatever reason - do not process the request.
 			return err
 		}
 		// If err is nil we got the right filtered namespace.
 		// If the input file is specified, and we failed to get the namespace, use all namespaces.
-		i2gw.Run(resourcePrinter, namespaceFilter, inputFile)
+		pr.namespaceFilter = ns
 		return nil
-	},
+	}
+
+	pr.namespaceFilter = pr.namespace
+	return nil
 }
 
-// getResourcePrinter returns a specific type of printers.ResourcePrinter
-// based on the provided outputFormat.
-func getResourcePrinter(outputFormat string) (printers.ResourcePrinter, error) {
-	switch outputFormat {
-	case "yaml", "":
-		return &printers.YAMLPrinter{}, nil
-	case "json":
-		return &printers.JSONPrinter{}, nil
-	default:
-		return nil, fmt.Errorf("%s is not a supported output format", outputFormat)
+func newPrintCommand() *cobra.Command {
+	pr := NewDefaultPrintRunner()
+	var printFlags genericclioptions.JSONYamlPrintFlags
+	allowedFormats := printFlags.AllowedFormats()
+
+	// printCmd represents the print command. It prints HTTPRoutes and Gateways
+	// generated from Ingress resources.
+	var cmd = &cobra.Command{
+		Use:   "print",
+		Short: "Prints HTTPRoutes and Gateways generated from Ingress resources",
+		RunE:  pr.PrintGatewaysAndHttpRoutes,
 	}
+
+	cmd.RunE = pr.PrintGatewaysAndHttpRoutes
+
+	cmd.Flags().StringVarP(&pr.outputFormat, "output", "o", "yaml",
+		fmt.Sprintf(`Output format. One of: (%s)`, strings.Join(allowedFormats, ", ")))
+
+	cmd.Flags().StringVar(&pr.inputFile, "input_file", "",
+		`Path to the manifest file. When set, the tool will read ingresses from the file instead of reading from the cluster. Supported files are yaml and json`)
+
+	cmd.Flags().StringVarP(&pr.namespace, "namespace", "n", "",
+		`If present, the namespace scope for this CLI request`)
+
+	cmd.Flags().BoolVarP(&pr.allNamespaces, "all-namespaces", "A", false,
+		`If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even
+if specified with --namespace.`)
+
+	cmd.MarkFlagsMutuallyExclusive("namespace", "all-namespaces")
+	return cmd
 }
 
 // getNamespaceFilter returns a namespace filter, taking into consideration whether a specific
 // namespace is requested, or all of them are.
-func getNamespaceFilter(requestedNamespace string, useAllNamespaces bool) (string, error) {
+func getNamespaceFilter(pr *PrintRunner) (string, error) {
 
 	// When we should use all namespaces, return an empty string.
 	// This is the first condition since it should override the requestedNamespace,
 	// if specified.
-	if useAllNamespaces {
+	if pr.allNamespaces {
 		return "", nil
 	}
 
-	if requestedNamespace == "" {
+	if pr.namespace == "" {
 		return getNamespaceInCurrentContext()
 	}
-	return requestedNamespace, nil
+	return pr.namespace, nil
 }
 
 // getNamespaceInCurrentContext returns the namespace in the current active context of the user.
@@ -109,23 +162,6 @@ func getNamespaceInCurrentContext() (string, error) {
 }
 
 func init() {
-	var printFlags genericclioptions.JSONYamlPrintFlags
-	allowedFormats := printFlags.AllowedFormats()
-
-	printCmd.Flags().StringVarP(&outputFormat, "output", "o", "yaml",
-		fmt.Sprintf(`Output format. One of: (%s)`, strings.Join(allowedFormats, ", ")))
-
-	printCmd.Flags().StringVar(&inputFile, "input_file", "",
-		`Path to the manifest file. When set, the tool will read ingresses from the file instead of reading from the cluster. Supported files are yaml and json`)
-
-	printCmd.Flags().StringVarP(&namespace, "namespace", "n", "",
-		`If present, the namespace scope for this CLI request`)
-
-	printCmd.Flags().BoolVarP(&allNamespaces, "all-namespaces", "A", false,
-		`If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even
-if specified with --namespace.`)
-
-	printCmd.MarkFlagsMutuallyExclusive("namespace", "all-namespaces")
-
+	printCmd := newPrintCommand()
 	rootCmd.AddCommand(printCmd)
 }

--- a/cmd/print.go
+++ b/cmd/print.go
@@ -56,14 +56,15 @@ var printCmd = &cobra.Command{
 			return err
 		}
 		namespaceFilter, err := getNamespaceFilter(namespace, allNamespaces)
-		if err == nil {
-			i2gw.Run(resourcePrinter, namespaceFilter, inputFile)
-			return nil
-		} else if clientcmd.IsConfigurationInvalid(err) && inputFile != "" {
-			// process all namespaces if context does not exist while reading from file
-			i2gw.Run(resourcePrinter, "", inputFile)
-			return nil
+		if err != nil && inputFile == "" {
+			// When asked to read from the cluster, but getting the current namespace
+			// failed for whatever reason - do not process the request.
+			return err
 		}
+		// If err is nil we got the right filtered namespace.
+		// If the input file is specified, and we failed to get the namespace, use all namespaces.
+		i2gw.Run(resourcePrinter, namespaceFilter, inputFile)
+		return nil
 		return err
 	},
 }

--- a/cmd/print_test.go
+++ b/cmd/print_test.go
@@ -62,7 +62,8 @@ func Test_getResourcePrinter(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result, err := getResourcePrinter(tc.outputFormat)
+			pr := PrintRunner{outputFormat: tc.outputFormat}
+			err := pr.InitializeResourcePrinter()
 
 			if tc.expectingError && err == nil {
 				t.Errorf("Expected error but got none")
@@ -71,8 +72,8 @@ func Test_getResourcePrinter(t *testing.T) {
 				t.Errorf("Expected no error but got %v", err)
 			}
 
-			if !reflect.DeepEqual(result, tc.expectedPrinter) {
-				t.Errorf("getResourcePrinter(%s) = %v, expected %v", tc.outputFormat, result, tc.expectedPrinter)
+			if !reflect.DeepEqual(pr.resourcePrinter, tc.expectedPrinter) {
+				t.Errorf("getResourcePrinter(%s) = %v, expected %v", tc.outputFormat, pr.resourcePrinter, tc.expectedPrinter)
 			}
 		})
 
@@ -122,7 +123,11 @@ func Test_getNamespaceFilter(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actualNamespaceFilter, err := getNamespaceFilter(tc.namespace, tc.allNamespaces)
+			pr := PrintRunner{
+				namespace:     tc.namespace,
+				allNamespaces: tc.allNamespaces,
+			}
+			err := pr.InitializeNamespaceFilter()
 
 			if tc.expectingError && err == nil {
 				t.Errorf("Expected error but got none")
@@ -132,12 +137,12 @@ func Test_getNamespaceFilter(t *testing.T) {
 			}
 
 			if tc.expectingCurrentNamespace {
-				tc.expectedNamespaceFilter, _ = getNamespaceFilter(tc.namespace, tc.allNamespaces)
+				tc.expectedNamespaceFilter = pr.namespaceFilter
 			}
 
-			if actualNamespaceFilter != tc.expectedNamespaceFilter {
+			if pr.namespaceFilter != tc.expectedNamespaceFilter {
 				t.Errorf(`getNamespaceFilter("%s", %v) = %v, expected %v`,
-					tc.namespace, tc.allNamespaces, actualNamespaceFilter, tc.expectedNamespaceFilter)
+					tc.namespace, tc.allNamespaces, pr.namespaceFilter, tc.expectedNamespaceFilter)
 			}
 		})
 

--- a/pkg/i2gw/ingress2gateway.go
+++ b/pkg/i2gw/ingress2gateway.go
@@ -31,62 +31,18 @@ import (
 	kubeyaml "k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/cli-runtime/pkg/printers"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
-func Run(printer printers.ResourcePrinter, namespace string, inputFile string) {
-	ingressList := &networkingv1.IngressList{}
-	if inputFile != "" {
-		err := constructIngressesFromFile(ingressList, inputFile, namespace)
-		if err != nil {
-			fmt.Printf("failed to open input file: %v\n", err)
-			os.Exit(1)
-		}
-	} else {
-		conf, err := config.GetConfig()
-		if err != nil {
-			fmt.Println("failed to get client config")
-			os.Exit(1)
-		}
-
-		cl, err := client.New(conf, client.Options{})
-		if err != nil {
-			fmt.Println("failed to create client")
-			os.Exit(1)
-		}
-		cl = client.NewNamespacedClient(cl, namespace)
-
-		err = cl.List(context.Background(), ingressList)
-		if err != nil {
-			fmt.Printf("failed to list ingresses: %v\n", err)
-			os.Exit(1)
-		}
+func ConstructIngressesFromKubeCluster(cl client.Client, ingressList *networkingv1.IngressList) error {
+	err := cl.List(context.Background(), ingressList)
+	if err != nil {
+		return fmt.Errorf("failed to get ingresses from the cluster: %v", err)
 	}
-
-	if len(ingressList.Items) == 0 {
-		msg := "No resources found"
-		if namespace != "" {
-			fmt.Printf("%s in %s namespace\n", msg, namespace)
-		} else {
-			fmt.Println(msg)
-		}
-		return
-	}
-
-	httpRoutes, gateways, errors := ingresses2GatewaysAndHTTPRoutes(ingressList.Items)
-	if len(errors) > 0 {
-		fmt.Printf("# Encountered %d errors\n", len(errors))
-		for _, err := range errors {
-			fmt.Printf("# %s\n", err)
-		}
-		return
-	}
-
-	outputResult(printer, httpRoutes, gateways)
+	return nil
 }
 
-func ingresses2GatewaysAndHTTPRoutes(ingresses []networkingv1.Ingress) ([]gatewayv1beta1.HTTPRoute, []gatewayv1beta1.Gateway, field.ErrorList) {
+func Ingresses2GatewaysAndHTTPRoutes(ingresses []networkingv1.Ingress) ([]gatewayv1beta1.HTTPRoute, []gatewayv1beta1.Gateway, field.ErrorList) {
 	aggregator := ingressAggregator{ruleGroups: map[ruleGroupKey]*ingressRuleGroup{}}
 
 	var errs field.ErrorList
@@ -100,7 +56,7 @@ func ingresses2GatewaysAndHTTPRoutes(ingresses []networkingv1.Ingress) ([]gatewa
 	return aggregator.toHTTPRoutesAndGateways()
 }
 
-func outputResult(printer printers.ResourcePrinter, httpRoutes []gatewayv1beta1.HTTPRoute, gateways []gatewayv1beta1.Gateway) {
+func OutputResult(printer printers.ResourcePrinter, httpRoutes []gatewayv1beta1.HTTPRoute, gateways []gatewayv1beta1.Gateway) {
 	for i := range gateways {
 		err := printer.PrintObj(&gateways[i], os.Stdout)
 		if err != nil {
@@ -160,10 +116,10 @@ func extractObjectsFromReader(reader io.Reader) ([]*unstructured.Unstructured, e
 	return finalObjs, nil
 }
 
-// constructIngressesFromFile reads the inputFile in either json/yaml formats,
+// ConstructIngressesFromFile reads the inputFile in either json/yaml formats,
 // then deserialize the file into Ingresses resources.
 // All ingresses will be pushed into the supplied IngressList for return.
-func constructIngressesFromFile(l *networkingv1.IngressList, inputFile string, namespace string) error {
+func ConstructIngressesFromFile(l *networkingv1.IngressList, inputFile string, namespace string) error {
 	stream, err := os.ReadFile(inputFile)
 	if err != nil {
 		return err

--- a/pkg/i2gw/ingress2gateway_test.go
+++ b/pkg/i2gw/ingress2gateway_test.go
@@ -29,85 +29,119 @@ func Test_constructIngressesFromFile(t *testing.T) {
 	iPrefix := networkingv1.PathTypePrefix
 	ingress1ClassName := "ingressClass1"
 	ingress2ClassName := "ingressClass2"
-
-	wantIngressList := []networkingv1.Ingress{
-		{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "Ingress",
-				APIVersion: "networking.k8s.io/v1",
-			},
-			ObjectMeta: metav1.ObjectMeta{Name: "ingress1"},
-			Spec: networkingv1.IngressSpec{
-				IngressClassName: &ingress1ClassName,
-				Rules: []networkingv1.IngressRule{{
-					IngressRuleValue: networkingv1.IngressRuleValue{
-						HTTP: &networkingv1.HTTPIngressRuleValue{
-							Paths: []networkingv1.HTTPIngressPath{{
-								Path:     "/test-1",
-								PathType: &iPrefix,
-								Backend: networkingv1.IngressBackend{
-									Service: &networkingv1.IngressServiceBackend{
-										Name: "test1",
-										Port: networkingv1.ServiceBackendPort{
-											Number: 443,
-										},
-									},
-								},
-							}},
-						},
-					},
-				}},
-			},
+	ingressNoNamespaceClassName := "ingressClassNoNamespace"
+	ingress1 := networkingv1.Ingress{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Ingress",
+			APIVersion: "networking.k8s.io/v1",
 		},
-		{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "Ingress",
-				APIVersion: "networking.k8s.io/v1",
-			},
-			ObjectMeta: metav1.ObjectMeta{Name: "ingress2"},
-			Spec: networkingv1.IngressSpec{
-				IngressClassName: &ingress2ClassName,
-				Rules: []networkingv1.IngressRule{{
-					IngressRuleValue: networkingv1.IngressRuleValue{
-						HTTP: &networkingv1.HTTPIngressRuleValue{
-							Paths: []networkingv1.HTTPIngressPath{{
-								Path:     "/test-2",
-								PathType: &iPrefix,
-								Backend: networkingv1.IngressBackend{
-									Service: &networkingv1.IngressServiceBackend{
-										Name: "test2",
-										Port: networkingv1.ServiceBackendPort{
-											Number: 80,
-										},
+		ObjectMeta: metav1.ObjectMeta{Name: "ingress1", Namespace: "namespace1"},
+		Spec: networkingv1.IngressSpec{
+			IngressClassName: &ingress1ClassName,
+			Rules: []networkingv1.IngressRule{{
+				IngressRuleValue: networkingv1.IngressRuleValue{
+					HTTP: &networkingv1.HTTPIngressRuleValue{
+						Paths: []networkingv1.HTTPIngressPath{{
+							Path:     "/test-1",
+							PathType: &iPrefix,
+							Backend: networkingv1.IngressBackend{
+								Service: &networkingv1.IngressServiceBackend{
+									Name: "test1",
+									Port: networkingv1.ServiceBackendPort{
+										Number: 443,
 									},
 								},
-							}},
-						},
+							},
+						}},
 					},
-				}},
-			},
+				},
+			}},
+		},
+	}
+	ingress2 := networkingv1.Ingress{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Ingress",
+			APIVersion: "networking.k8s.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{Name: "ingress2", Namespace: "namespace2"},
+		Spec: networkingv1.IngressSpec{
+			IngressClassName: &ingress2ClassName,
+			Rules: []networkingv1.IngressRule{{
+				IngressRuleValue: networkingv1.IngressRuleValue{
+					HTTP: &networkingv1.HTTPIngressRuleValue{
+						Paths: []networkingv1.HTTPIngressPath{{
+							Path:     "/test-2",
+							PathType: &iPrefix,
+							Backend: networkingv1.IngressBackend{
+								Service: &networkingv1.IngressServiceBackend{
+									Name: "test2",
+									Port: networkingv1.ServiceBackendPort{
+										Number: 80,
+									},
+								},
+							},
+						}},
+					},
+				},
+			}},
+		},
+	}
+	ingressNoNamespace := networkingv1.Ingress{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Ingress",
+			APIVersion: "networking.k8s.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{Name: "ingress-no-namespace"},
+		Spec: networkingv1.IngressSpec{
+			IngressClassName: &ingressNoNamespaceClassName,
+			Rules: []networkingv1.IngressRule{{
+				IngressRuleValue: networkingv1.IngressRuleValue{
+					HTTP: &networkingv1.HTTPIngressRuleValue{
+						Paths: []networkingv1.HTTPIngressPath{{
+							Path:     "/test-no-namespace",
+							PathType: &iPrefix,
+							Backend: networkingv1.IngressBackend{
+								Service: &networkingv1.IngressServiceBackend{
+									Name: "test-no-namespace",
+									Port: networkingv1.ServiceBackendPort{
+										Number: 80,
+									},
+								},
+							},
+						}},
+					},
+				},
+			}},
 		},
 	}
 
 	testCases := []struct {
 		name            string
 		filePath        string
+		namespace       string
 		wantIngressList []networkingv1.Ingress
 	}{{
-		name:            "Test yaml input file with multiple resources",
+		name:            "Test yaml input file with multiple resources with no namespace flag",
 		filePath:        "testdata/input-file.yaml",
-		wantIngressList: wantIngressList,
+		namespace:       "",
+		wantIngressList: []networkingv1.Ingress{ingress1, ingress2, ingressNoNamespace},
 	}, {
-		name:            "Test json input file with multiple resources",
+		name:            "Test json input file with multiple resources with no namespace flag",
 		filePath:        "testdata/input-file.json",
-		wantIngressList: wantIngressList,
+		namespace:       "",
+		wantIngressList: []networkingv1.Ingress{ingress1, ingress2, ingressNoNamespace},
+	}, {
+		name:            "Test yaml input file with multiple resources with namespace1 flag",
+		filePath:        "testdata/input-file.yaml",
+		namespace:       "namespace1",
+		wantIngressList: []networkingv1.Ingress{ingress1},
 	},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			gotIngressList := &networkingv1.IngressList{}
-			err := constructIngressesFromFile(gotIngressList, tc.filePath)
+			err := constructIngressesFromFile(gotIngressList, tc.filePath, tc.namespace)
 			if err != nil {
 				t.Errorf("Failed to open test file: %v", err)
 			}

--- a/pkg/i2gw/ingress2gateway_test.go
+++ b/pkg/i2gw/ingress2gateway_test.go
@@ -141,7 +141,7 @@ func Test_constructIngressesFromFile(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			gotIngressList := &networkingv1.IngressList{}
-			err := constructIngressesFromFile(gotIngressList, tc.filePath, tc.namespace)
+			err := ConstructIngressesFromFile(gotIngressList, tc.filePath, tc.namespace)
 			if err != nil {
 				t.Errorf("Failed to open test file: %v", err)
 			}

--- a/pkg/i2gw/testdata/input-file.json
+++ b/pkg/i2gw/testdata/input-file.json
@@ -61,7 +61,8 @@
             "apiVersion": "networking.k8s.io/v1",
             "kind": "Ingress",
             "metadata": {
-                "name": "ingress1"
+                "name": "ingress1",
+                "namespace": "namespace1"
             },
             "spec": {
                 "ingressClassName": "ingressClass1",
@@ -91,7 +92,8 @@
             "apiVersion": "networking.k8s.io/v1",
             "kind": "Ingress",
             "metadata": {
-                "name": "ingress2"
+                "name": "ingress2",
+                "namespace": "namespace2"
             },
             "spec": {
                 "ingressClassName": "ingressClass2",
@@ -105,6 +107,36 @@
                                     "backend": {
                                         "service": {
                                             "name": "test2",
+                                            "port": {
+                                                "number": 80
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "apiVersion": "networking.k8s.io/v1",
+            "kind": "Ingress",
+            "metadata": {
+                "name": "ingress-no-namespace"
+            },
+            "spec": {
+                "ingressClassName": "ingressClassNoNamespace",
+                "rules": [
+                    {
+                        "http": {
+                            "paths": [
+                                {
+                                    "path": "/test-no-namespace",
+                                    "pathType": "Prefix",
+                                    "backend": {
+                                        "service": {
+                                            "name": "test-no-namespace",
                                             "port": {
                                                 "number": 80
                                             }

--- a/pkg/i2gw/testdata/input-file.yaml
+++ b/pkg/i2gw/testdata/input-file.yaml
@@ -33,6 +33,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: ingress1
+  namespace: namespace1
 spec:
   ingressClassName: ingressClass1
   rules:
@@ -50,6 +51,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: ingress2
+  namespace: namespace2
 spec:
   ingressClassName: ingressClass2
   rules:
@@ -60,5 +62,22 @@ spec:
         backend:
           service:
             name: test2
+            port:
+              number: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress-no-namespace
+spec:
+  ingressClassName: ingressClassNoNamespace
+  rules:
+  - http:
+      paths:
+      - path: /test-no-namespace
+        pathType: Prefix
+        backend:
+          service:
+            name: test-no-namespace
             port:
               number: 80


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it**:
This breaks the `Run()` method in ingress2gateway.go down to utility methods and use them in print.go. This helps extending the functionalities in the future as we may introduce `apply` instead of just `print` for example

Fixes https://github.com/kubernetes-sigs/ingress2gateway/issues/41

```release-note
NONE
```
