### PR TITLE
implement test for constructIngressFromCluster

### DIFF
--- a/pkg/i2gw/ingress2gateway_test.go
+++ b/pkg/i2gw/ingress2gateway_test.go
@@ -19,13 +19,12 @@ package i2gw
 import (
 	"testing"
 
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-
 	"github.com/google/go-cmp/cmp"
 	networkingv1 "k8s.io/api/networking/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func Test_constructIngressesFromFile(t *testing.T) {

--- a/pkg/i2gw/ingress2gateway_test.go
+++ b/pkg/i2gw/ingress2gateway_test.go
@@ -74,9 +74,9 @@ func ingress(port int32, name, namespace string) networkingv1.Ingress {
 	iService := "service-" + name
 	var objMeta metav1.ObjectMeta
 	if namespace != "" {
-		objMeta = metav1.ObjectMeta{Name: name, ResourceVersion: "999", Namespace: namespace}
+		objMeta = metav1.ObjectMeta{Name: name, Namespace: namespace}
 	} else {
-		objMeta = metav1.ObjectMeta{Name: name, ResourceVersion: "999"}
+		objMeta = metav1.ObjectMeta{Name: name}
 	}
 
 	ing := networkingv1.Ingress{

--- a/pkg/i2gw/ingress2gateway_test.go
+++ b/pkg/i2gw/ingress2gateway_test.go
@@ -28,9 +28,9 @@ import (
 )
 
 func Test_constructIngressesFromFile(t *testing.T) {
-	ingress1 := createIngress(443, "ingress1", "namespace1", "/test-1", "ingressClass1")
-	ingress2 := createIngress(80, "ingress2", "namespace2", "/test-2", "ingressClass2")
-	ingressNoNamespace := createIngress(80, "ingress-no-namespace", "", "/test-no-namespace", "ingressClassNoNamespace")
+	ingress1 := ingress(443, "ingress1", "namespace1")
+	ingress2 := ingress(80, "ingress2", "namespace2")
+	ingressNoNamespace := ingress(80, "ingress-no-namespace", "")
 
 	testCases := []struct {
 		name            string
@@ -67,8 +67,11 @@ func Test_constructIngressesFromFile(t *testing.T) {
 	}
 }
 
-func createIngress(port int32, name, namespace, path, ingressClass string) networkingv1.Ingress {
+func ingress(port int32, name, namespace string) networkingv1.Ingress {
 	iPrefix := networkingv1.PathTypePrefix
+	iPath := "/path-" + name
+	iClass := "ingressClass-" + name
+	iService := "service-" + name
 	var objMeta metav1.ObjectMeta
 	if namespace != "" {
 		objMeta = metav1.ObjectMeta{Name: name, ResourceVersion: "999", Namespace: namespace}
@@ -83,16 +86,16 @@ func createIngress(port int32, name, namespace, path, ingressClass string) netwo
 		},
 		ObjectMeta: objMeta,
 		Spec: networkingv1.IngressSpec{
-			IngressClassName: &ingressClass,
+			IngressClassName: &iClass,
 			Rules: []networkingv1.IngressRule{{
 				IngressRuleValue: networkingv1.IngressRuleValue{
 					HTTP: &networkingv1.HTTPIngressRuleValue{
 						Paths: []networkingv1.HTTPIngressPath{{
-							Path:     path,
+							Path:     iPath,
 							PathType: &iPrefix,
 							Backend: networkingv1.IngressBackend{
 								Service: &networkingv1.IngressServiceBackend{
-									Name: name,
+									Name: iService,
 									Port: networkingv1.ServiceBackendPort{
 										Number: port,
 									},
@@ -117,8 +120,8 @@ func compareIngressLists(t *testing.T, gotIngressList *networkingv1.IngressList,
 }
 
 func Test_constructIngressesFromCluster(t *testing.T) {
-	ingress1 := createIngress(443, "ingress1", "namespace1", "/test-1", "ingressClass1")
-	ingress2 := createIngress(80, "ingress2", "namespace2", "/test-2", "ingressClass2")
+	ingress1 := ingress(443, "ingress1", "namespace1")
+	ingress2 := ingress(80, "ingress2", "namespace2")
 	testCases := []struct {
 		name          string
 		runtimeObjs   []runtime.Object

--- a/pkg/i2gw/ingress2gateway_test.go
+++ b/pkg/i2gw/ingress2gateway_test.go
@@ -74,9 +74,9 @@ func ingress(port int32, name, namespace string) networkingv1.Ingress {
 	iService := "service-" + name
 	var objMeta metav1.ObjectMeta
 	if namespace != "" {
-		objMeta = metav1.ObjectMeta{Name: name, Namespace: namespace}
+		objMeta = metav1.ObjectMeta{Name: name, ResourceVersion: "999", Namespace: namespace}
 	} else {
-		objMeta = metav1.ObjectMeta{Name: name}
+		objMeta = metav1.ObjectMeta{Name: name, ResourceVersion: "999"}
 	}
 
 	ing := networkingv1.Ingress{

--- a/pkg/i2gw/ingress2gateway_test.go
+++ b/pkg/i2gw/ingress2gateway_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package i2gw
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -69,9 +70,7 @@ func Test_constructIngressesFromFile(t *testing.T) {
 
 func ingress(port int32, name, namespace string) networkingv1.Ingress {
 	iPrefix := networkingv1.PathTypePrefix
-	iPath := "/path-" + name
-	iClass := "ingressClass-" + name
-	iService := "service-" + name
+	ingressClassName := fmt.Sprintf("ingressClass-%s", name)
 	var objMeta metav1.ObjectMeta
 	if namespace != "" {
 		objMeta = metav1.ObjectMeta{Name: name, ResourceVersion: "999", Namespace: namespace}
@@ -86,16 +85,16 @@ func ingress(port int32, name, namespace string) networkingv1.Ingress {
 		},
 		ObjectMeta: objMeta,
 		Spec: networkingv1.IngressSpec{
-			IngressClassName: &iClass,
+			IngressClassName: &ingressClassName,
 			Rules: []networkingv1.IngressRule{{
 				IngressRuleValue: networkingv1.IngressRuleValue{
 					HTTP: &networkingv1.HTTPIngressRuleValue{
 						Paths: []networkingv1.HTTPIngressPath{{
-							Path:     iPath,
+							Path:     fmt.Sprintf("/path-%s", name),
 							PathType: &iPrefix,
 							Backend: networkingv1.IngressBackend{
 								Service: &networkingv1.IngressServiceBackend{
-									Name: iService,
+									Name: fmt.Sprintf("service-%s", name),
 									Port: networkingv1.ServiceBackendPort{
 										Number: port,
 									},

--- a/pkg/i2gw/testdata/input-file.json
+++ b/pkg/i2gw/testdata/input-file.json
@@ -62,7 +62,8 @@
             "kind": "Ingress",
             "metadata": {
                 "name": "ingress1",
-                "namespace": "namespace1"
+                "namespace": "namespace1",
+                "resourceVersion": "999"
             },
             "spec": {
                 "ingressClassName": "ingressClass-ingress1",
@@ -93,7 +94,8 @@
             "kind": "Ingress",
             "metadata": {
                 "name": "ingress2",
-                "namespace": "namespace2"
+                "namespace": "namespace2",
+                "resourceVersion": "999"
             },
             "spec": {
                 "ingressClassName": "ingressClass-ingress2",
@@ -123,7 +125,8 @@
             "apiVersion": "networking.k8s.io/v1",
             "kind": "Ingress",
             "metadata": {
-                "name": "ingress-no-namespace"
+                "name": "ingress-no-namespace",
+                "resourceVersion": "999"
             },
             "spec": {
                 "ingressClassName": "ingressClass-ingress-no-namespace",

--- a/pkg/i2gw/testdata/input-file.json
+++ b/pkg/i2gw/testdata/input-file.json
@@ -75,7 +75,7 @@
                                     "pathType": "Prefix",
                                     "backend": {
                                         "service": {
-                                            "name": "test1",
+                                            "name": "ingress1",
                                             "port": {
                                                 "number": 443
                                             }
@@ -106,7 +106,7 @@
                                     "pathType": "Prefix",
                                     "backend": {
                                         "service": {
-                                            "name": "test2",
+                                            "name": "ingress2",
                                             "port": {
                                                 "number": 80
                                             }
@@ -136,7 +136,7 @@
                                     "pathType": "Prefix",
                                     "backend": {
                                         "service": {
-                                            "name": "test-no-namespace",
+                                            "name": "ingress-no-namespace",
                                             "port": {
                                                 "number": 80
                                             }

--- a/pkg/i2gw/testdata/input-file.json
+++ b/pkg/i2gw/testdata/input-file.json
@@ -65,17 +65,17 @@
                 "namespace": "namespace1"
             },
             "spec": {
-                "ingressClassName": "ingressClass1",
+                "ingressClassName": "ingressClass-ingress1",
                 "rules": [
                     {
                         "http": {
                             "paths": [
                                 {
-                                    "path": "/test-1",
+                                    "path": "/path-ingress1",
                                     "pathType": "Prefix",
                                     "backend": {
                                         "service": {
-                                            "name": "ingress1",
+                                            "name": "service-ingress1",
                                             "port": {
                                                 "number": 443
                                             }
@@ -96,17 +96,17 @@
                 "namespace": "namespace2"
             },
             "spec": {
-                "ingressClassName": "ingressClass2",
+                "ingressClassName": "ingressClass-ingress2",
                 "rules": [
                     {
                         "http": {
                             "paths": [
                                 {
-                                    "path": "/test-2",
+                                    "path": "/path-ingress2",
                                     "pathType": "Prefix",
                                     "backend": {
                                         "service": {
-                                            "name": "ingress2",
+                                            "name": "service-ingress2",
                                             "port": {
                                                 "number": 80
                                             }
@@ -126,17 +126,17 @@
                 "name": "ingress-no-namespace"
             },
             "spec": {
-                "ingressClassName": "ingressClassNoNamespace",
+                "ingressClassName": "ingressClass-ingress-no-namespace",
                 "rules": [
                     {
                         "http": {
                             "paths": [
                                 {
-                                    "path": "/test-no-namespace",
+                                    "path": "/path-ingress-no-namespace",
                                     "pathType": "Prefix",
                                     "backend": {
                                         "service": {
-                                            "name": "ingress-no-namespace",
+                                            "name": "service-ingress-no-namespace",
                                             "port": {
                                                 "number": 80
                                             }

--- a/pkg/i2gw/testdata/input-file.yaml
+++ b/pkg/i2gw/testdata/input-file.yaml
@@ -35,15 +35,15 @@ metadata:
   name: ingress1
   namespace: namespace1
 spec:
-  ingressClassName: ingressClass1
+  ingressClassName: ingressClass-ingress1
   rules:
   - http:
       paths:
-      - path: /test-1
+      - path: /path-ingress1
         pathType: Prefix
         backend:
           service:
-            name: ingress1
+            name: service-ingress1
             port:
               number: 443
 ---
@@ -53,15 +53,15 @@ metadata:
   name: ingress2
   namespace: namespace2
 spec:
-  ingressClassName: ingressClass2
+  ingressClassName: ingressClass-ingress2
   rules:
   - http:
       paths:
-      - path: /test-2
+      - path: /path-ingress2
         pathType: Prefix
         backend:
           service:
-            name: ingress2
+            name: service-ingress2
             port:
               number: 80
 ---
@@ -70,14 +70,14 @@ kind: Ingress
 metadata:
   name: ingress-no-namespace
 spec:
-  ingressClassName: ingressClassNoNamespace
+  ingressClassName: ingressClass-ingress-no-namespace
   rules:
   - http:
       paths:
-      - path: /test-no-namespace
+      - path: /path-ingress-no-namespace
         pathType: Prefix
         backend:
           service:
-            name: ingress-no-namespace
+            name: service-ingress-no-namespace
             port:
               number: 80

--- a/pkg/i2gw/testdata/input-file.yaml
+++ b/pkg/i2gw/testdata/input-file.yaml
@@ -34,6 +34,7 @@ kind: Ingress
 metadata:
   name: ingress1
   namespace: namespace1
+  resourceVersion: "999"
 spec:
   ingressClassName: ingressClass-ingress1
   rules:
@@ -52,6 +53,7 @@ kind: Ingress
 metadata:
   name: ingress2
   namespace: namespace2
+  resourceVersion: "999"
 spec:
   ingressClassName: ingressClass-ingress2
   rules:
@@ -69,6 +71,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: ingress-no-namespace
+  resourceVersion: "999"
 spec:
   ingressClassName: ingressClass-ingress-no-namespace
   rules:

--- a/pkg/i2gw/testdata/input-file.yaml
+++ b/pkg/i2gw/testdata/input-file.yaml
@@ -43,7 +43,7 @@ spec:
         pathType: Prefix
         backend:
           service:
-            name: test1
+            name: ingress1
             port:
               number: 443
 ---
@@ -61,7 +61,7 @@ spec:
         pathType: Prefix
         backend:
           service:
-            name: test2
+            name: ingress2
             port:
               number: 80
 ---
@@ -78,6 +78,6 @@ spec:
         pathType: Prefix
         backend:
           service:
-            name: test-no-namespace
+            name: ingress-no-namespace
             port:
               number: 80


### PR DESCRIPTION
**What type of PR is this?**
/kind test

**What this PR does / why we need it**:
We need this test to get full coverage on all methods that get ingresses from different sources (e.g. from file and from cluster)

Fixes https://github.com/kubernetes-sigs/ingress2gateway/issues/48

```release-note
NONE
```
