### PR TITLE
Support to specify providers to execute convert action

### DIFF
--- a/cmd/print.go
+++ b/cmd/print.go
@@ -54,6 +54,9 @@ type PrintRunner struct {
 
 	// Only resources that matches this filter will be processed.
 	namespaceFilter string
+
+	// providers indicates which providers are used to execute convert action.
+	providers []string
 }
 
 // PrintGatewaysAndHTTPRoutes performs necessary steps to digest and print
@@ -69,7 +72,7 @@ func (pr *PrintRunner) PrintGatewaysAndHTTPRoutes(cmd *cobra.Command, _ []string
 		return fmt.Errorf("failed to initialize namespace filter: %w", err)
 	}
 
-	httpRoutes, gateways, err := i2gw.ToGatewayAPIResources(cmd.Context(), pr.namespaceFilter, pr.inputFile)
+	httpRoutes, gateways, err := i2gw.ToGatewayAPIResources(cmd.Context(), pr.namespaceFilter, pr.inputFile, pr.providers)
 	if err != nil {
 		return err
 	}
@@ -175,6 +178,9 @@ func newPrintCommand() *cobra.Command {
 	cmd.Flags().BoolVarP(&pr.allNamespaces, "all-namespaces", "A", false,
 		`If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even
 if specified with --namespace.`)
+
+	cmd.Flags().StringSliceVar(&pr.providers, "providers", i2gw.GetSupportedProviders(),
+		fmt.Sprintf("If present, the tool will try to convert only resources related to the specified providers, supported values are %v", i2gw.GetSupportedProviders()))
 
 	cmd.MarkFlagsMutuallyExclusive("namespace", "all-namespaces")
 	return cmd


### PR DESCRIPTION
Add a new flag `--provider`, in order to users to choose which concrete providers should be used when executing the 'print' command.

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

**What this PR does / why we need it**:

Now, we already refactor the layout in order to support multiple providers #40. We also need a mechanism to enables users to choose which concrete providers should be used when executing the 'print' command.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #45

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Add a new flag `--provider`, that enables users to choose which concrete providers should be used when executing the 'print' command.
```
