### PR TITLE
Add ingressonly flag

### DIFF
--- a/cmd/print.go
+++ b/cmd/print.go
@@ -57,6 +57,9 @@ type PrintRunner struct {
 
 	// providers indicates which providers are used to execute convert action.
 	providers []string
+
+	// If present, the tool will only print the converted Ingresses.
+	ingressesOnly bool
 }
 
 // PrintGatewaysAndHTTPRoutes performs necessary steps to digest and print
@@ -70,6 +73,10 @@ func (pr *PrintRunner) PrintGatewaysAndHTTPRoutes(cmd *cobra.Command, _ []string
 	err = pr.initializeNamespaceFilter()
 	if err != nil {
 		return fmt.Errorf("failed to initialize namespace filter: %w", err)
+	}
+
+	if pr.ingressesOnly {
+		pr.providers = nil
 	}
 
 	httpRoutes, gateways, err := i2gw.ToGatewayAPIResources(cmd.Context(), pr.namespaceFilter, pr.inputFile, pr.providers)
@@ -182,7 +189,10 @@ if specified with --namespace.`)
 	cmd.Flags().StringSliceVar(&pr.providers, "providers", i2gw.GetSupportedProviders(),
 		fmt.Sprintf("If present, the tool will try to convert only resources related to the specified providers, supported values are %v", i2gw.GetSupportedProviders()))
 
+	cmd.Flags().BoolVar(&pr.ingressesOnly, "ingresses-only", false, "If present, the tool will only print the converted Ingresses.")
+
 	cmd.MarkFlagsMutuallyExclusive("namespace", "all-namespaces")
+	cmd.MarkFlagsMutuallyExclusive("ingresses-only", "providers")
 	return cmd
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
this adds a new flag ingresses-only to scope the tool to only convert resources without looking for providers CRDs

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #67 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
