### PR TITLE
Kong plugins feature

### DIFF
--- a/pkg/i2gw/providers/kong/README.md
+++ b/pkg/i2gw/providers/kong/README.md
@@ -12,5 +12,8 @@ Current supported annotations:
   in the annotation key after `.`, and the annotations value can contain multiple
   header values separated by commas. All the header values for a specific header
   name are intended to be ORed. Example: `konghq.com/headers.x-routing: "alpha,bravo"`.
+- `konghq.com/plugins`: If specified, the values of this annotation are used to
+  configure plugins on the associated ingress rules. Multiple plugins can be specified
+  by separating values with commas. Example: `konghq.com/plugins: "plugin1,plugin2"`.
 
 If you are reliant on any annotations not listed above, please open an issue.

--- a/pkg/i2gw/providers/kong/annotations.go
+++ b/pkg/i2gw/providers/kong/annotations.go
@@ -23,6 +23,7 @@ const (
 
 	headersKey = "headers"
 	methodsKey = "methods"
+	pluginsKey = "plugins"
 )
 
 func kongAnnotation(suffix string) string {

--- a/pkg/i2gw/providers/kong/converter.go
+++ b/pkg/i2gw/providers/kong/converter.go
@@ -36,6 +36,7 @@ func newConverter(conf *i2gw.ProviderConf) *converter {
 		featureParsers: []i2gw.FeatureParser{
 			headerMatchingFeature,
 			methodMatchingFeature,
+			pluginsFeature,
 		},
 	}
 }

--- a/pkg/i2gw/providers/kong/converter_test.go
+++ b/pkg/i2gw/providers/kong/converter_test.go
@@ -42,7 +42,7 @@ func Test_ToGateway(t *testing.T) {
 		expectedErrors           field.ErrorList
 	}{
 		{
-			name: "header matching, method matching, single ingress rule",
+			name: "header matching, method matching, plugin, single ingress rule",
 			ingresses: []networkingv1.Ingress{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -51,6 +51,7 @@ func Test_ToGateway(t *testing.T) {
 						Annotations: map[string]string{
 							"konghq.com/headers.key1": "val1",
 							"konghq.com/methods":      "GET,POST",
+							"konghq.com/plugins":      "plugin1",
 						},
 					},
 					Spec: networkingv1.IngressSpec{
@@ -129,6 +130,16 @@ func Test_ToGateway(t *testing.T) {
 											},
 										},
 										Method: ptrTo(gatewayv1beta1.HTTPMethodPost),
+									},
+								},
+								Filters: []gatewayv1beta1.HTTPRouteFilter{
+									{
+										Type: gatewayv1beta1.HTTPRouteFilterExtensionRef,
+										ExtensionRef: &gatewayv1beta1.LocalObjectReference{
+											Group: gatewayv1beta1.Group("configuration.konghq.com/v1"),
+											Kind:  gatewayv1beta1.Kind("KongPlugin"),
+											Name:  gatewayv1beta1.ObjectName("plugin1"),
+										},
 									},
 								},
 								BackendRefs: []gatewayv1beta1.HTTPBackendRef{

--- a/pkg/i2gw/providers/kong/converter_test.go
+++ b/pkg/i2gw/providers/kong/converter_test.go
@@ -136,8 +136,8 @@ func Test_ToGateway(t *testing.T) {
 									{
 										Type: gatewayv1beta1.HTTPRouteFilterExtensionRef,
 										ExtensionRef: &gatewayv1beta1.LocalObjectReference{
-											Group: gatewayv1beta1.Group("configuration.konghq.com/v1"),
-											Kind:  gatewayv1beta1.Kind("KongPlugin"),
+											Group: kongPluginGroup,
+											Kind:  kongPluginKind,
 											Name:  gatewayv1beta1.ObjectName("plugin1"),
 										},
 									},

--- a/pkg/i2gw/providers/kong/method_matching_test.go
+++ b/pkg/i2gw/providers/kong/method_matching_test.go
@@ -29,7 +29,7 @@ import (
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
-func TestPathMatchingFeature(t *testing.T) {
+func TestMethodMatchingFeature(t *testing.T) {
 	iPrefix := networkingv1.PathTypePrefix
 
 	testCases := []struct {

--- a/pkg/i2gw/providers/kong/plugins.go
+++ b/pkg/i2gw/providers/kong/plugins.go
@@ -26,6 +26,11 @@ import (
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
+const (
+	kongPluginGroup gatewayv1beta1.Group = "configuration.konghq.com/v1"
+	kongPluginKind  gatewayv1beta1.Kind  = "KongPlugin"
+)
+
 // pluginsFeature parses the Kong Ingress Controller plugins annotation and converts it
 // into HTTPRoutes rule's ExtensionRef filters.
 // It's possible to define a list of plugins to attach to the same HTTPRoute by setting
@@ -61,8 +66,8 @@ func parsePluginsAnnotation(ingressNamespace, ingressName string, annotations ma
 				filters = append(filters, gatewayv1beta1.HTTPRouteFilter{
 					Type: gatewayv1beta1.HTTPRouteFilterExtensionRef,
 					ExtensionRef: &gatewayv1beta1.LocalObjectReference{
-						Group: gatewayv1beta1.Group("configuration.konghq.com/v1"),
-						Kind:  gatewayv1beta1.Kind("KongPlugin"),
+						Group: kongPluginGroup,
+						Kind:  kongPluginKind,
 						Name:  gatewayv1beta1.ObjectName(v),
 					},
 				})


### PR DESCRIPTION
**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

Kong plugins feature. The `konhq.com/plugins` ingress annotation is converted to a list of `ExtensionRef` filters.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
[Kong Provider] Add support for converting the `konghq.com/plugins` ingress annotation to a list of `ExtensionRef` HTTPRoute filters.
```
