### PR TITLE
Adding changelog for v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,17 @@
 
 ## Table of Contents
 
+- [v0.1.0](#v010)
 - [v0.1.0-rc1](#v010-rc1)
+
+## v0.1.0
+The first official release of ingress2gateway.
+
+### Notable changes since v0.1.0-rc1
+
+### Feature
+
+- [Kong Provider] Add support for converting the `konghq.com/plugins` ingress annotation to a list of `ExtensionRef` HTTPRoute filters. (#72, @mlavacca)
 
 ## v0.1.0-rc1
 initial release candidate. 


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
This adds the changelog for v0.1.0. Consensus on this PR means approval for v0.1.0 release

(Also fix some change in release.yaml I accidentally added in the previous PR)
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```

/cc @levikobi @robscott 
