### PR TITLE
fix: ingress rules order is preserved

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/google/go-cmp v0.6.0
 	github.com/spf13/cobra v1.8.0
-	istio.io/api v1.20.0
+	github.com/stretchr/testify v1.8.4
 	k8s.io/api v0.28.4
 	k8s.io/apimachinery v0.28.4
 	k8s.io/cli-runtime v0.28.4
@@ -13,6 +13,11 @@ require (
 	k8s.io/utils v0.0.0-20231121161247-cf03d44ff3cf
 	sigs.k8s.io/controller-runtime v0.16.3
 	sigs.k8s.io/gateway-api v0.5.0
+)
+
+require (
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	istio.io/api v1.20.0 // indirect
 )
 
 require (
@@ -63,7 +68,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	istio.io/client-go v1.19.0-alpha.1.0.20231130185426-9f1859c8ff42 // indirect
+	istio.io/client-go v1.19.0-alpha.1.0.20231130185426-9f1859c8ff42
 	k8s.io/klog/v2 v2.110.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20231113174909-778a5567bc1e // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect

--- a/go.sum
+++ b/go.sum
@@ -109,6 +109,7 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/xlab/treeprint v1.2.0 h1:HzHnuAF1plUN2zGlAFHbSQP2qJ0ZAD3XF5XD7OesXRQ=
 github.com/xlab/treeprint v1.2.0/go.mod h1:gj5Gd3gPdKtR1ikdDK6fnFLdmIS0X30kTTuNd/WEJu0=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/pkg/i2gw/providers/common/converter.go
+++ b/pkg/i2gw/providers/common/converter.go
@@ -268,11 +268,6 @@ func (a *ingressAggregator) toHTTPRoutesAndGateways(options i2gw.ProviderImpleme
 	return httpRoutes, gateways, errors
 }
 
-type pathsByMatchGroupType struct {
-	key   string
-	paths []ingressPath
-}
-
 func (rg *ingressRuleGroup) toHTTPRoute(options i2gw.ProviderImplementationSpecificOptions) (gatewayv1beta1.HTTPRoute, field.ErrorList) {
 	pathsByMatchGroup := groupPaths(rg.rules)
 	httpRoute := gatewayv1beta1.HTTPRoute{

--- a/pkg/i2gw/providers/common/converter.go
+++ b/pkg/i2gw/providers/common/converter.go
@@ -292,8 +292,9 @@ func (rg *ingressRuleGroup) toHTTPRoute(options i2gw.ProviderImplementationSpeci
 	}
 
 	var errors field.ErrorList
-	for _, paths := range pathsByMatchGroup {
-		path := paths.paths[0]
+	for _, key := range pathsByMatchGroup.keys {
+		paths := pathsByMatchGroup.data[key]
+		path := paths[0]
 		fieldPath := field.NewPath("spec", "rules").Index(path.ruleIdx).Child(path.ruleType).Child("paths").Index(path.pathIdx)
 		match, err := toHTTPRouteMatch(path.path, fieldPath, options.ToImplementationSpecificHTTPPathTypeMatch)
 		if err != nil {
@@ -304,7 +305,7 @@ func (rg *ingressRuleGroup) toHTTPRoute(options i2gw.ProviderImplementationSpeci
 			Matches: []gatewayv1beta1.HTTPRouteMatch{*match},
 		}
 
-		backendRefs, errs := rg.configureBackendRef(paths.paths)
+		backendRefs, errs := rg.configureBackendRef(paths)
 		errors = append(errors, errs...)
 		hrRule.BackendRefs = backendRefs
 

--- a/pkg/i2gw/providers/common/converter.go
+++ b/pkg/i2gw/providers/common/converter.go
@@ -269,7 +269,7 @@ func (a *ingressAggregator) toHTTPRoutesAndGateways(options i2gw.ProviderImpleme
 }
 
 func (rg *ingressRuleGroup) toHTTPRoute(options i2gw.ProviderImplementationSpecificOptions) (gatewayv1beta1.HTTPRoute, field.ErrorList) {
-	pathsByMatchGroup := groupIngressPathsByMatchKey(rg.rules)
+	ingressPathsByMatchKey := groupIngressPathsByMatchKey(rg.rules)
 	httpRoute := gatewayv1beta1.HTTPRoute{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      RouteName(rg.name, rg.host),
@@ -292,8 +292,8 @@ func (rg *ingressRuleGroup) toHTTPRoute(options i2gw.ProviderImplementationSpeci
 	}
 
 	var errors field.ErrorList
-	for _, key := range pathsByMatchGroup.keys {
-		paths := pathsByMatchGroup.data[key]
+	for _, key := range ingressPathsByMatchKey.keys {
+		paths := ingressPathsByMatchKey.data[key]
 		path := paths[0]
 		fieldPath := field.NewPath("spec", "rules").Index(path.ruleIdx).Child(path.ruleType).Child("paths").Index(path.pathIdx)
 		match, err := toHTTPRouteMatch(path.path, fieldPath, options.ToImplementationSpecificHTTPPathTypeMatch)

--- a/pkg/i2gw/providers/common/converter.go
+++ b/pkg/i2gw/providers/common/converter.go
@@ -269,7 +269,7 @@ func (a *ingressAggregator) toHTTPRoutesAndGateways(options i2gw.ProviderImpleme
 }
 
 func (rg *ingressRuleGroup) toHTTPRoute(options i2gw.ProviderImplementationSpecificOptions) (gatewayv1beta1.HTTPRoute, field.ErrorList) {
-	pathsByMatchGroup := groupPaths(rg.rules)
+	pathsByMatchGroup := groupIngressPathsByMatchKey(rg.rules)
 	httpRoute := gatewayv1beta1.HTTPRoute{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      RouteName(rg.name, rg.host),

--- a/pkg/i2gw/providers/common/utils.go
+++ b/pkg/i2gw/providers/common/utils.go
@@ -134,16 +134,13 @@ type orderedIngressPathsByMatchKey struct {
 
 func groupIngressPathsByMatchKey(rules []ingressRule) orderedIngressPathsByMatchKey {
 	// we use a slice instead of a map to preserve rules order
-	pathsByMatchGroup := orderedIngressPathsByMatchKey{}
+	pathsByMatchGroup := orderedIngressPathsByMatchKey{
+		keys: []pathMatchKey{},
+		data: map[pathMatchKey][]ingressPath{},
+	}
 
 	for i, ir := range rules {
 		for j, path := range ir.rule.HTTP.Paths {
-			if len(pathsByMatchGroup.keys) == 0 {
-				pathsByMatchGroup.keys = []pathMatchKey{}
-			}
-			if len(pathsByMatchGroup.data) == 0 {
-				pathsByMatchGroup.data = map[pathMatchKey][]ingressPath{}
-			}
 			ip := ingressPath{ruleIdx: i, pathIdx: j, ruleType: "http", path: path}
 			pmKey := getPathMatchKey(ip)
 			if _, ok := pathsByMatchGroup.data[pmKey]; !ok {

--- a/pkg/i2gw/providers/common/utils.go
+++ b/pkg/i2gw/providers/common/utils.go
@@ -133,7 +133,7 @@ type orderedIngressPathsByMatchKey struct {
 }
 
 func groupIngressPathsByMatchKey(rules []ingressRule) orderedIngressPathsByMatchKey {
-	// we use a slice instead of a map to preserve rules order
+	// we track the keys in an additional slice in order to preserve the rules order
 	pathsByMatchGroup := orderedIngressPathsByMatchKey{
 		keys: []pathMatchKey{},
 		data: map[pathMatchKey][]ingressPath{},

--- a/pkg/i2gw/providers/common/utils.go
+++ b/pkg/i2gw/providers/common/utils.go
@@ -134,7 +134,7 @@ type orderedIngressPathsByMatchKey struct {
 
 func groupIngressPathsByMatchKey(rules []ingressRule) orderedIngressPathsByMatchKey {
 	// we track the keys in an additional slice in order to preserve the rules order
-	pathsByMatchGroup := orderedIngressPathsByMatchKey{
+	ingressPathsByMatchKey := orderedIngressPathsByMatchKey{
 		keys: []pathMatchKey{},
 		data: map[pathMatchKey][]ingressPath{},
 	}
@@ -143,13 +143,13 @@ func groupIngressPathsByMatchKey(rules []ingressRule) orderedIngressPathsByMatch
 		for j, path := range ir.rule.HTTP.Paths {
 			ip := ingressPath{ruleIdx: i, pathIdx: j, ruleType: "http", path: path}
 			pmKey := getPathMatchKey(ip)
-			if _, ok := pathsByMatchGroup.data[pmKey]; !ok {
-				pathsByMatchGroup.keys = append(pathsByMatchGroup.keys, pmKey)
+			if _, ok := ingressPathsByMatchKey.data[pmKey]; !ok {
+				ingressPathsByMatchKey.keys = append(ingressPathsByMatchKey.keys, pmKey)
 			}
-			pathsByMatchGroup.data[pmKey] = append(pathsByMatchGroup.data[pmKey], ip)
+			ingressPathsByMatchKey.data[pmKey] = append(ingressPathsByMatchKey.data[pmKey], ip)
 		}
 	}
-	return pathsByMatchGroup
+	return ingressPathsByMatchKey
 }
 
 func PtrTo[T any](a T) *T {

--- a/pkg/i2gw/providers/common/utils.go
+++ b/pkg/i2gw/providers/common/utils.go
@@ -127,6 +127,11 @@ func ToBackendRef(ib networkingv1.IngressBackend, path *field.Path) (*gatewayv1b
 	}, nil
 }
 
+type pathsByMatchGroupType struct {
+	key   string
+	paths []ingressPath
+}
+
 func groupPaths(rules []ingressRule) []pathsByMatchGroupType {
 	// we use a slice instead of a map to preserve rules order
 	pathsByMatchGroup := []pathsByMatchGroupType{}

--- a/pkg/i2gw/providers/common/utils.go
+++ b/pkg/i2gw/providers/common/utils.go
@@ -127,14 +127,14 @@ func ToBackendRef(ib networkingv1.IngressBackend, path *field.Path) (*gatewayv1b
 	}, nil
 }
 
-type orderedPathsByMatchGroup struct {
+type orderedIngressPathsByMatchKey struct {
 	keys []pathMatchKey
 	data map[pathMatchKey][]ingressPath
 }
 
-func groupPaths(rules []ingressRule) orderedPathsByMatchGroup {
+func groupIngressPathsByMatchKey(rules []ingressRule) orderedIngressPathsByMatchKey {
 	// we use a slice instead of a map to preserve rules order
-	pathsByMatchGroup := orderedPathsByMatchGroup{}
+	pathsByMatchGroup := orderedIngressPathsByMatchKey{}
 
 	for i, ir := range rules {
 		for j, path := range ir.rule.HTTP.Paths {

--- a/pkg/i2gw/providers/common/utils_test.go
+++ b/pkg/i2gw/providers/common/utils_test.go
@@ -29,12 +29,12 @@ func TestGroupPaths(t *testing.T) {
 	testCases := []struct {
 		name     string
 		rules    []ingressRule
-		expected []pathsByMatchGroupType
+		expected orderedPathsByMatchGroup
 	}{
 		{
 			name:     "no rules",
 			rules:    []ingressRule{},
-			expected: []pathsByMatchGroupType{},
+			expected: orderedPathsByMatchGroup{},
 		},
 		{
 			name: "1 rule with 1 match",
@@ -62,10 +62,12 @@ func TestGroupPaths(t *testing.T) {
 					},
 				},
 			},
-			expected: []pathsByMatchGroupType{
-				{
-					key: "Prefix//test",
-					paths: []ingressPath{
+			expected: orderedPathsByMatchGroup{
+				keys: []pathMatchKey{
+					"Prefix//test",
+				},
+				data: map[pathMatchKey][]ingressPath{
+					"Prefix//test": {
 						{
 							ruleIdx:  0,
 							pathIdx:  0,
@@ -125,10 +127,13 @@ func TestGroupPaths(t *testing.T) {
 					},
 				},
 			},
-			expected: []pathsByMatchGroupType{
-				{
-					key: "Prefix//test1",
-					paths: []ingressPath{
+			expected: orderedPathsByMatchGroup{
+				keys: []pathMatchKey{
+					"Prefix//test1",
+					"Prefix//test2",
+				},
+				data: map[pathMatchKey][]ingressPath{
+					"Prefix//test1": {
 						{
 							ruleIdx:  0,
 							pathIdx:  0,
@@ -147,10 +152,7 @@ func TestGroupPaths(t *testing.T) {
 							},
 						},
 					},
-				},
-				{
-					key: "Prefix//test2",
-					paths: []ingressPath{
+					"Prefix//test2": {
 						{
 							ruleIdx:  0,
 							pathIdx:  1,
@@ -220,10 +222,12 @@ func TestGroupPaths(t *testing.T) {
 					},
 				},
 			},
-			expected: []pathsByMatchGroupType{
-				{
-					key: "Prefix//test",
-					paths: []ingressPath{
+			expected: orderedPathsByMatchGroup{
+				keys: []pathMatchKey{
+					"Prefix//test",
+				},
+				data: map[pathMatchKey][]ingressPath{
+					"Prefix//test": {
 						{
 							ruleIdx:  0,
 							pathIdx:  0,
@@ -310,10 +314,13 @@ func TestGroupPaths(t *testing.T) {
 					},
 				},
 			},
-			expected: []pathsByMatchGroupType{
-				{
-					key: "Prefix//test",
-					paths: []ingressPath{
+			expected: orderedPathsByMatchGroup{
+				keys: []pathMatchKey{
+					"Prefix//test",
+					"Prefix//test2",
+				},
+				data: map[pathMatchKey][]ingressPath{
+					"Prefix//test": {
 						{
 							ruleIdx:  0,
 							pathIdx:  0,
@@ -332,10 +339,7 @@ func TestGroupPaths(t *testing.T) {
 							},
 						},
 					},
-				},
-				{
-					key: "Prefix//test2",
-					paths: []ingressPath{
+					"Prefix//test2": {
 						{
 							ruleIdx:  1,
 							pathIdx:  0,
@@ -429,10 +433,14 @@ func TestGroupPaths(t *testing.T) {
 					},
 				},
 			},
-			expected: []pathsByMatchGroupType{
-				{
-					key: "Prefix//test11",
-					paths: []ingressPath{
+			expected: orderedPathsByMatchGroup{
+				keys: []pathMatchKey{
+					"Prefix//test11",
+					"Prefix//test12",
+					"Prefix//test21",
+				},
+				data: map[pathMatchKey][]ingressPath{
+					"Prefix//test11": {
 						{
 							ruleIdx:  0,
 							pathIdx:  0,
@@ -468,10 +476,7 @@ func TestGroupPaths(t *testing.T) {
 							},
 						},
 					},
-				},
-				{
-					key: "Prefix//test12",
-					paths: []ingressPath{
+					"Prefix//test12": {
 						{
 							ruleIdx:  0,
 							pathIdx:  1,
@@ -490,10 +495,7 @@ func TestGroupPaths(t *testing.T) {
 							},
 						},
 					},
-				},
-				{
-					key: "Prefix//test21",
-					paths: []ingressPath{
+					"Prefix//test21": {
 						{
 							ruleIdx:  1,
 							pathIdx:  0,

--- a/pkg/i2gw/providers/common/utils_test.go
+++ b/pkg/i2gw/providers/common/utils_test.go
@@ -32,9 +32,12 @@ func TestGroupPaths(t *testing.T) {
 		expected orderedIngressPathsByMatchKey
 	}{
 		{
-			name:     "no rules",
-			rules:    []ingressRule{},
-			expected: orderedIngressPathsByMatchKey{},
+			name:  "no rules",
+			rules: []ingressRule{},
+			expected: orderedIngressPathsByMatchKey{
+				keys: []pathMatchKey{},
+				data: map[pathMatchKey][]ingressPath{},
+			},
 		},
 		{
 			name: "1 rule with 1 match",

--- a/pkg/i2gw/providers/common/utils_test.go
+++ b/pkg/i2gw/providers/common/utils_test.go
@@ -1,0 +1,527 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	networkingv1 "k8s.io/api/networking/v1"
+)
+
+func TestGroupPaths(t *testing.T) {
+	iPrefix := networkingv1.PathTypePrefix
+
+	testCases := []struct {
+		name     string
+		rules    []ingressRule
+		expected []pathsByMatchGroupType
+	}{
+		{
+			name:     "no rules",
+			rules:    []ingressRule{},
+			expected: []pathsByMatchGroupType{},
+		},
+		{
+			name: "1 rule with 1 match",
+			rules: []ingressRule{
+				{
+					networkingv1.IngressRule{
+						IngressRuleValue: networkingv1.IngressRuleValue{
+							HTTP: &networkingv1.HTTPIngressRuleValue{
+								Paths: []networkingv1.HTTPIngressPath{
+									{
+										Path:     "/test",
+										PathType: PtrTo(networkingv1.PathTypePrefix),
+										Backend: networkingv1.IngressBackend{
+											Service: &networkingv1.IngressServiceBackend{
+												Name: "test",
+												Port: networkingv1.ServiceBackendPort{
+													Number: 80,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: []pathsByMatchGroupType{
+				{
+					key: "Prefix//test",
+					paths: []ingressPath{
+						{
+							ruleIdx:  0,
+							pathIdx:  0,
+							ruleType: "http",
+							path: networkingv1.HTTPIngressPath{
+								Path:     "/test",
+								PathType: &iPrefix,
+								Backend: networkingv1.IngressBackend{
+									Service: &networkingv1.IngressServiceBackend{
+										Name: "test",
+										Port: networkingv1.ServiceBackendPort{
+											Number: 80,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "1 rule, multiple matches, different path",
+			rules: []ingressRule{
+				{
+					networkingv1.IngressRule{
+						IngressRuleValue: networkingv1.IngressRuleValue{
+							HTTP: &networkingv1.HTTPIngressRuleValue{
+								Paths: []networkingv1.HTTPIngressPath{
+									{
+										Path:     "/test1",
+										PathType: PtrTo(networkingv1.PathTypePrefix),
+										Backend: networkingv1.IngressBackend{
+											Service: &networkingv1.IngressServiceBackend{
+												Name: "test1",
+												Port: networkingv1.ServiceBackendPort{
+													Number: 80,
+												},
+											},
+										},
+									},
+									{
+										Path:     "/test2",
+										PathType: PtrTo(networkingv1.PathTypePrefix),
+										Backend: networkingv1.IngressBackend{
+											Service: &networkingv1.IngressServiceBackend{
+												Name: "test2",
+												Port: networkingv1.ServiceBackendPort{
+													Number: 80,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: []pathsByMatchGroupType{
+				{
+					key: "Prefix//test1",
+					paths: []ingressPath{
+						{
+							ruleIdx:  0,
+							pathIdx:  0,
+							ruleType: "http",
+							path: networkingv1.HTTPIngressPath{
+								Path:     "/test1",
+								PathType: &iPrefix,
+								Backend: networkingv1.IngressBackend{
+									Service: &networkingv1.IngressServiceBackend{
+										Name: "test1",
+										Port: networkingv1.ServiceBackendPort{
+											Number: 80,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					key: "Prefix//test2",
+					paths: []ingressPath{
+						{
+							ruleIdx:  0,
+							pathIdx:  1,
+							ruleType: "http",
+							path: networkingv1.HTTPIngressPath{
+								Path:     "/test2",
+								PathType: &iPrefix,
+								Backend: networkingv1.IngressBackend{
+									Service: &networkingv1.IngressServiceBackend{
+										Name: "test2",
+										Port: networkingv1.ServiceBackendPort{
+											Number: 80,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "multiple rules with single matches, same path",
+			rules: []ingressRule{
+				{
+					networkingv1.IngressRule{
+						IngressRuleValue: networkingv1.IngressRuleValue{
+							HTTP: &networkingv1.HTTPIngressRuleValue{
+								Paths: []networkingv1.HTTPIngressPath{
+									{
+										Path:     "/test",
+										PathType: PtrTo(networkingv1.PathTypePrefix),
+										Backend: networkingv1.IngressBackend{
+											Service: &networkingv1.IngressServiceBackend{
+												Name: "test",
+												Port: networkingv1.ServiceBackendPort{
+													Number: 80,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					networkingv1.IngressRule{
+						IngressRuleValue: networkingv1.IngressRuleValue{
+							HTTP: &networkingv1.HTTPIngressRuleValue{
+								Paths: []networkingv1.HTTPIngressPath{
+									{
+										Path:     "/test",
+										PathType: PtrTo(networkingv1.PathTypePrefix),
+										Backend: networkingv1.IngressBackend{
+											Service: &networkingv1.IngressServiceBackend{
+												Name: "test",
+												Port: networkingv1.ServiceBackendPort{
+													Number: 81,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: []pathsByMatchGroupType{
+				{
+					key: "Prefix//test",
+					paths: []ingressPath{
+						{
+							ruleIdx:  0,
+							pathIdx:  0,
+							ruleType: "http",
+							path: networkingv1.HTTPIngressPath{
+								Path:     "/test",
+								PathType: &iPrefix,
+								Backend: networkingv1.IngressBackend{
+									Service: &networkingv1.IngressServiceBackend{
+										Name: "test",
+										Port: networkingv1.ServiceBackendPort{
+											Number: 80,
+										},
+									},
+								},
+							},
+						},
+						{
+							ruleIdx:  1,
+							pathIdx:  0,
+							ruleType: "http",
+							path: networkingv1.HTTPIngressPath{
+								Path:     "/test",
+								PathType: &iPrefix,
+								Backend: networkingv1.IngressBackend{
+									Service: &networkingv1.IngressServiceBackend{
+										Name: "test",
+										Port: networkingv1.ServiceBackendPort{
+											Number: 81,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "multiple rules with single matches, different path",
+			rules: []ingressRule{
+				{
+					networkingv1.IngressRule{
+						IngressRuleValue: networkingv1.IngressRuleValue{
+							HTTP: &networkingv1.HTTPIngressRuleValue{
+								Paths: []networkingv1.HTTPIngressPath{
+									{
+										Path:     "/test",
+										PathType: PtrTo(networkingv1.PathTypePrefix),
+										Backend: networkingv1.IngressBackend{
+											Service: &networkingv1.IngressServiceBackend{
+												Name: "test",
+												Port: networkingv1.ServiceBackendPort{
+													Number: 80,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					networkingv1.IngressRule{
+						IngressRuleValue: networkingv1.IngressRuleValue{
+							HTTP: &networkingv1.HTTPIngressRuleValue{
+								Paths: []networkingv1.HTTPIngressPath{
+									{
+										Path:     "/test2",
+										PathType: PtrTo(networkingv1.PathTypePrefix),
+										Backend: networkingv1.IngressBackend{
+											Service: &networkingv1.IngressServiceBackend{
+												Name: "test2",
+												Port: networkingv1.ServiceBackendPort{
+													Number: 81,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: []pathsByMatchGroupType{
+				{
+					key: "Prefix//test",
+					paths: []ingressPath{
+						{
+							ruleIdx:  0,
+							pathIdx:  0,
+							ruleType: "http",
+							path: networkingv1.HTTPIngressPath{
+								Path:     "/test",
+								PathType: &iPrefix,
+								Backend: networkingv1.IngressBackend{
+									Service: &networkingv1.IngressServiceBackend{
+										Name: "test",
+										Port: networkingv1.ServiceBackendPort{
+											Number: 80,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					key: "Prefix//test2",
+					paths: []ingressPath{
+						{
+							ruleIdx:  1,
+							pathIdx:  0,
+							ruleType: "http",
+							path: networkingv1.HTTPIngressPath{
+								Path:     "/test2",
+								PathType: &iPrefix,
+								Backend: networkingv1.IngressBackend{
+									Service: &networkingv1.IngressServiceBackend{
+										Name: "test2",
+										Port: networkingv1.ServiceBackendPort{
+											Number: 81,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "multiple rules with multiple matches, mixed paths",
+			rules: []ingressRule{
+				{
+					networkingv1.IngressRule{
+						IngressRuleValue: networkingv1.IngressRuleValue{
+							HTTP: &networkingv1.HTTPIngressRuleValue{
+								Paths: []networkingv1.HTTPIngressPath{
+									{
+										Path:     "/test11",
+										PathType: PtrTo(networkingv1.PathTypePrefix),
+										Backend: networkingv1.IngressBackend{
+											Service: &networkingv1.IngressServiceBackend{
+												Name: "test11",
+												Port: networkingv1.ServiceBackendPort{
+													Number: 80,
+												},
+											},
+										},
+									},
+									{
+										Path:     "/test12",
+										PathType: PtrTo(networkingv1.PathTypePrefix),
+										Backend: networkingv1.IngressBackend{
+											Service: &networkingv1.IngressServiceBackend{
+												Name: "test12",
+												Port: networkingv1.ServiceBackendPort{
+													Number: 80,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					networkingv1.IngressRule{
+						IngressRuleValue: networkingv1.IngressRuleValue{
+							HTTP: &networkingv1.HTTPIngressRuleValue{
+								Paths: []networkingv1.HTTPIngressPath{
+									{
+										Path:     "/test21",
+										PathType: PtrTo(networkingv1.PathTypePrefix),
+										Backend: networkingv1.IngressBackend{
+											Service: &networkingv1.IngressServiceBackend{
+												Name: "test21",
+												Port: networkingv1.ServiceBackendPort{
+													Number: 81,
+												},
+											},
+										},
+									},
+									{
+										Path:     "/test11",
+										PathType: PtrTo(networkingv1.PathTypePrefix),
+										Backend: networkingv1.IngressBackend{
+											Service: &networkingv1.IngressServiceBackend{
+												Name: "test11",
+												Port: networkingv1.ServiceBackendPort{
+													Number: 81,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: []pathsByMatchGroupType{
+				{
+					key: "Prefix//test11",
+					paths: []ingressPath{
+						{
+							ruleIdx:  0,
+							pathIdx:  0,
+							ruleType: "http",
+							path: networkingv1.HTTPIngressPath{
+								Path:     "/test11",
+								PathType: &iPrefix,
+								Backend: networkingv1.IngressBackend{
+									Service: &networkingv1.IngressServiceBackend{
+										Name: "test11",
+										Port: networkingv1.ServiceBackendPort{
+											Number: 80,
+										},
+									},
+								},
+							},
+						},
+						{
+							ruleIdx:  1,
+							pathIdx:  1,
+							ruleType: "http",
+							path: networkingv1.HTTPIngressPath{
+								Path:     "/test11",
+								PathType: &iPrefix,
+								Backend: networkingv1.IngressBackend{
+									Service: &networkingv1.IngressServiceBackend{
+										Name: "test11",
+										Port: networkingv1.ServiceBackendPort{
+											Number: 81,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					key: "Prefix//test12",
+					paths: []ingressPath{
+						{
+							ruleIdx:  0,
+							pathIdx:  1,
+							ruleType: "http",
+							path: networkingv1.HTTPIngressPath{
+								Path:     "/test12",
+								PathType: &iPrefix,
+								Backend: networkingv1.IngressBackend{
+									Service: &networkingv1.IngressServiceBackend{
+										Name: "test12",
+										Port: networkingv1.ServiceBackendPort{
+											Number: 80,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					key: "Prefix//test21",
+					paths: []ingressPath{
+						{
+							ruleIdx:  1,
+							pathIdx:  0,
+							ruleType: "http",
+							path: networkingv1.HTTPIngressPath{
+								Path:     "/test21",
+								PathType: &iPrefix,
+								Backend: networkingv1.IngressBackend{
+									Service: &networkingv1.IngressServiceBackend{
+										Name: "test21",
+										Port: networkingv1.ServiceBackendPort{
+											Number: 81,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			want := groupPaths(tc.rules)
+			require.Equal(t, want, tc.expected)
+		})
+	}
+}

--- a/pkg/i2gw/providers/common/utils_test.go
+++ b/pkg/i2gw/providers/common/utils_test.go
@@ -29,12 +29,12 @@ func TestGroupPaths(t *testing.T) {
 	testCases := []struct {
 		name     string
 		rules    []ingressRule
-		expected orderedPathsByMatchGroup
+		expected orderedIngressPathsByMatchKey
 	}{
 		{
 			name:     "no rules",
 			rules:    []ingressRule{},
-			expected: orderedPathsByMatchGroup{},
+			expected: orderedIngressPathsByMatchKey{},
 		},
 		{
 			name: "1 rule with 1 match",
@@ -62,7 +62,7 @@ func TestGroupPaths(t *testing.T) {
 					},
 				},
 			},
-			expected: orderedPathsByMatchGroup{
+			expected: orderedIngressPathsByMatchKey{
 				keys: []pathMatchKey{
 					"Prefix//test",
 				},
@@ -127,7 +127,7 @@ func TestGroupPaths(t *testing.T) {
 					},
 				},
 			},
-			expected: orderedPathsByMatchGroup{
+			expected: orderedIngressPathsByMatchKey{
 				keys: []pathMatchKey{
 					"Prefix//test1",
 					"Prefix//test2",
@@ -222,7 +222,7 @@ func TestGroupPaths(t *testing.T) {
 					},
 				},
 			},
-			expected: orderedPathsByMatchGroup{
+			expected: orderedIngressPathsByMatchKey{
 				keys: []pathMatchKey{
 					"Prefix//test",
 				},
@@ -314,7 +314,7 @@ func TestGroupPaths(t *testing.T) {
 					},
 				},
 			},
-			expected: orderedPathsByMatchGroup{
+			expected: orderedIngressPathsByMatchKey{
 				keys: []pathMatchKey{
 					"Prefix//test",
 					"Prefix//test2",
@@ -433,7 +433,7 @@ func TestGroupPaths(t *testing.T) {
 					},
 				},
 			},
-			expected: orderedPathsByMatchGroup{
+			expected: orderedIngressPathsByMatchKey{
 				keys: []pathMatchKey{
 					"Prefix//test11",
 					"Prefix//test12",
@@ -522,7 +522,7 @@ func TestGroupPaths(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			want := groupPaths(tc.rules)
+			want := groupIngressPathsByMatchKey(tc.rules)
 			require.Equal(t, want, tc.expected)
 		})
 	}

--- a/pkg/i2gw/providers/common/utils_test.go
+++ b/pkg/i2gw/providers/common/utils_test.go
@@ -23,7 +23,7 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 )
 
-func TestGroupPaths(t *testing.T) {
+func TestGroupIngressPathsByMatchKey(t *testing.T) {
 	iPrefix := networkingv1.PathTypePrefix
 
 	testCases := []struct {

--- a/pkg/i2gw/providers/ingressnginx/canary.go
+++ b/pkg/i2gw/providers/ingressnginx/canary.go
@@ -33,12 +33,12 @@ func canaryFeature(ingressResources i2gw.InputResources, gatewayResources *i2gw.
 	ruleGroups := common.GetRuleGroups(ingressResources.Ingresses)
 
 	for _, rg := range ruleGroups {
-		pathsByMatchGroup, errs := getPathsByMatchGroups(rg)
+		ingressPathsByMatchKey, errs := getPathsByMatchGroups(rg)
 		if len(errs) > 0 {
 			return errs
 		}
 
-		for _, paths := range pathsByMatchGroup {
+		for _, paths := range ingressPathsByMatchKey {
 			path := paths[0]
 
 			backendRefs, calculationErrs := calculateBackendRefWeight(paths)
@@ -61,7 +61,7 @@ func canaryFeature(ingressResources i2gw.InputResources, gatewayResources *i2gw.
 }
 
 func getPathsByMatchGroups(rg common.IngressRuleGroup) (map[pathMatchKey][]ingressPath, field.ErrorList) {
-	pathsByMatchGroup := map[pathMatchKey][]ingressPath{}
+	ingressPathsByMatchKey := map[pathMatchKey][]ingressPath{}
 
 	for _, ir := range rg.Rules {
 
@@ -76,11 +76,11 @@ func getPathsByMatchGroups(rg common.IngressRuleGroup) (map[pathMatchKey][]ingre
 		for _, path := range ir.IngressRule.HTTP.Paths {
 			ip := ingressPath{ingress: ingress, ruleType: "http", path: path, extra: &extraFeatures}
 			pmKey := getPathMatchKey(ip)
-			pathsByMatchGroup[pmKey] = append(pathsByMatchGroup[pmKey], ip)
+			ingressPathsByMatchKey[pmKey] = append(ingressPathsByMatchKey[pmKey], ip)
 		}
 	}
 
-	return pathsByMatchGroup, nil
+	return ingressPathsByMatchKey, nil
 }
 
 func patchHTTPRouteWithBackendRefs(httpRoute *gatewayv1beta1.HTTPRoute, backendRefs []gatewayv1beta1.HTTPBackendRef) {


### PR DESCRIPTION
**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

**What this PR does / why we need it**:

Ingress Rules order needs to be preserved when converting into `HTTPRoute` rules.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #91

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
