### PR TITLE
[Revert the revert] Change ingress fetching to be isolated per provider

### DIFF
--- a/pkg/i2gw/ingress2gateway.go
+++ b/pkg/i2gw/ingress2gateway.go
@@ -45,30 +45,19 @@ func ToGatewayAPIResources(ctx context.Context, namespace string, inputFile stri
 	}
 	cl = client.NewNamespacedClient(cl, namespace)
 
-	var ingresses networkingv1.IngressList
-
 	providerByName, err := constructProviders(&ProviderConf{
-		Client: cl,
+		Client:    cl,
+		Namespace: namespace,
 	}, providers)
 	if err != nil {
 		return nil, err
 	}
 
-	resources := InputResources{}
-
 	if inputFile != "" {
-		if err = ConstructIngressesFromFile(&ingresses, inputFile, namespace); err != nil {
-			return nil, fmt.Errorf("failed to read ingresses from file: %w", err)
-		}
-		resources.Ingresses = ingresses.Items
 		if err = readProviderResourcesFromFile(ctx, providerByName, inputFile); err != nil {
 			return nil, err
 		}
 	} else {
-		if err = ConstructIngressesFromCluster(ctx, cl, &ingresses); err != nil {
-			return nil, fmt.Errorf("failed to read ingresses from cluster: %w", err)
-		}
-		resources.Ingresses = ingresses.Items
 		if err = readProviderResourcesFromCluster(ctx, providerByName); err != nil {
 			return nil, err
 		}
@@ -79,7 +68,8 @@ func ToGatewayAPIResources(ctx context.Context, namespace string, inputFile stri
 		errs             field.ErrorList
 	)
 	for _, provider := range providerByName {
-		providerGatewayResources, conversionErrs := provider.ToGatewayAPI(resources)
+		// TODO(#113) Remove input resources from ToGatewayAPI function
+		providerGatewayResources, conversionErrs := provider.ToGatewayAPI(InputResources{})
 		errs = append(errs, conversionErrs...)
 		gatewayResources = append(gatewayResources, providerGatewayResources)
 	}
@@ -136,7 +126,8 @@ func constructProviders(conf *ProviderConf, providers []string) (map[ProviderNam
 // ExtractObjectsFromReader extracts all objects from a reader,
 // which is created from YAML or JSON input files.
 // It retrieves all objects, including nested ones if they are contained within a list.
-func ExtractObjectsFromReader(reader io.Reader) ([]*unstructured.Unstructured, error) {
+// The function takes a namespace parameter to optionally return only namespaced resources.
+func ExtractObjectsFromReader(reader io.Reader, namespace string) ([]*unstructured.Unstructured, error) {
 	d := kubeyaml.NewYAMLOrJSONDecoder(reader, 4096)
 	var objs []*unstructured.Unstructured
 	for {
@@ -148,6 +139,9 @@ func ExtractObjectsFromReader(reader io.Reader) ([]*unstructured.Unstructured, e
 			return objs, fmt.Errorf("failed to unmarshal manifest: %w", err)
 		}
 		if u == nil {
+			continue
+		}
+		if namespace != "" && u.GetNamespace() != namespace {
 			continue
 		}
 		objs = append(objs, u)
@@ -187,15 +181,12 @@ func ConstructIngressesFromFile(l *networkingv1.IngressList, inputFile string, n
 	}
 
 	reader := bytes.NewReader(stream)
-	objs, err := ExtractObjectsFromReader(reader)
+	objs, err := ExtractObjectsFromReader(reader, namespace)
 	if err != nil {
 		return err
 	}
 
 	for _, f := range objs {
-		if namespace != "" && f.GetNamespace() != namespace {
-			continue
-		}
 		if !f.GroupVersionKind().Empty() && f.GroupVersionKind().Kind == "Ingress" {
 			var i networkingv1.Ingress
 			err = runtime.DefaultUnstructuredConverter.

--- a/pkg/i2gw/ingress2gateway_test.go
+++ b/pkg/i2gw/ingress2gateway_test.go
@@ -17,19 +17,21 @@ limitations under the License.
 package i2gw
 
 import (
-	"context"
+	"bytes"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	networkingv1 "k8s.io/api/networking/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-func Test_constructIngressesFromFile(t *testing.T) {
+func Test_ExtractObjectsFromReader(t *testing.T) {
 	ingress1 := ingress(443, "ingress1", "namespace1")
 	ingress2 := ingress(80, "ingress2", "namespace2")
 	ingressNoNamespace := ingress(80, "ingress-no-namespace", "")
@@ -60,10 +62,17 @@ func Test_constructIngressesFromFile(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			gotIngressList := &networkingv1.IngressList{}
-			err := ConstructIngressesFromFile(gotIngressList, tc.filePath, tc.namespace)
+			stream, err := os.ReadFile(tc.filePath)
 			if err != nil {
-				t.Errorf("Failed to open test file: %v", err)
+				t.Errorf("failed to read file %s: %v", tc.filePath, err)
+			}
+			unstructuredObjects, err := ExtractObjectsFromReader(bytes.NewReader(stream), tc.namespace)
+			if err != nil {
+				t.Errorf("failed to extract objects: %s", err)
+			}
+			gotIngressList, err := ingressListFromUnstructured(unstructuredObjects)
+			if err != nil {
+				t.Errorf("got unexpected error: %v", err)
 			}
 			compareIngressLists(t, gotIngressList, tc.wantIngressList)
 		})
@@ -111,43 +120,27 @@ func ingress(port int32, name, namespace string) networkingv1.Ingress {
 	return ing
 }
 
+func ingressListFromUnstructured(unstructuredObjects []*unstructured.Unstructured) (*networkingv1.IngressList, error) {
+	ingressList := &networkingv1.IngressList{}
+	for _, f := range unstructuredObjects {
+		if !f.GroupVersionKind().Empty() && f.GroupVersionKind().Kind == "Ingress" {
+			var i networkingv1.Ingress
+			err := runtime.DefaultUnstructuredConverter.
+				FromUnstructured(f.UnstructuredContent(), &i)
+			if err != nil {
+				return nil, err
+			}
+			ingressList.Items = append(ingressList.Items, i)
+		}
+	}
+	return ingressList, nil
+}
 func compareIngressLists(t *testing.T, gotIngressList *networkingv1.IngressList, wantIngressList []networkingv1.Ingress) {
 	for i, got := range gotIngressList.Items {
 		want := wantIngressList[i]
 		if !apiequality.Semantic.DeepEqual(got, want) {
 			t.Errorf("Expected Ingress %d to be %+v\n Got: %+v\n Diff: %s", i, want, got, cmp.Diff(want, got))
 		}
-	}
-}
-
-func Test_constructIngressesFromCluster(t *testing.T) {
-	ingress1 := ingress(443, "ingress1", "namespace1")
-	ingress2 := ingress(80, "ingress2", "namespace2")
-	testCases := []struct {
-		name          string
-		runtimeObjs   []runtime.Object
-		wantIngresses []networkingv1.Ingress
-	}{{
-		name:          "Test cluster client with 2 resources",
-		runtimeObjs:   []runtime.Object{&ingress1, &ingress2},
-		wantIngresses: []networkingv1.Ingress{ingress1, ingress2},
-	}, {
-		name:          "Test cluster client without resources",
-		runtimeObjs:   []runtime.Object{},
-		wantIngresses: []networkingv1.Ingress{},
-	},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			gotIngresses := &networkingv1.IngressList{}
-			cl := fake.NewClientBuilder().WithRuntimeObjects(tc.runtimeObjs...).Build()
-			err := ConstructIngressesFromCluster(context.Background(), cl, gotIngresses)
-			if err != nil {
-				t.Errorf("test failed unexpectedly: %v", err)
-			}
-			compareIngressLists(t, gotIngresses, tc.wantIngresses)
-		})
 	}
 }
 

--- a/pkg/i2gw/provider.go
+++ b/pkg/i2gw/provider.go
@@ -42,7 +42,8 @@ type ProviderConstructor func(conf *ProviderConf) Provider
 // ProviderConf contains all the configuration required for every concrete
 // Provider implementation.
 type ProviderConf struct {
-	Client client.Client
+	Client    client.Client
+	Namespace string
 }
 
 // The Provider interface specifies the required functionality which needs to be

--- a/pkg/i2gw/providers/ingressnginx/converter.go
+++ b/pkg/i2gw/providers/ingressnginx/converter.go
@@ -19,40 +19,42 @@ package ingressnginx
 import (
 	"github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw"
 	"github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw/providers/common"
+	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
 // converter implements the ToGatewayAPI function of i2gw.ResourceConverter interface.
 type converter struct {
-	conf *i2gw.ProviderConf
-
 	featureParsers []i2gw.FeatureParser
 }
 
 // newConverter returns an ingress-nginx converter instance.
-func newConverter(conf *i2gw.ProviderConf) *converter {
+func newConverter() *converter {
 	return &converter{
-		conf: conf,
 		featureParsers: []i2gw.FeatureParser{
 			canaryFeature,
 		},
 	}
 }
 
-// ToGatewayAPI converts the received i2gw.InputResources to i2gw.GatewayResources
-// including the ingress-nginx specific features.
-func (c *converter) ToGatewayAPI(resources i2gw.InputResources) (i2gw.GatewayResources, field.ErrorList) {
+func (c *converter) convert(storage *storage) (i2gw.GatewayResources, field.ErrorList) {
+
+	// TODO(liorliberman) temporary until we decide to change ToGateway and featureParsers to get a map of [types.NamespacedName]*networkingv1.Ingress instead of a list
+	ingressList := []networkingv1.Ingress{}
+	for _, ing := range storage.Ingresses {
+		ingressList = append(ingressList, *ing)
+	}
 
 	// Convert plain ingress resources to gateway resources, ignoring all
 	// provider-specific features.
-	gatewayResources, errs := common.ToGateway(resources.Ingresses, i2gw.ProviderImplementationSpecificOptions{})
+	gatewayResources, errs := common.ToGateway(ingressList, i2gw.ProviderImplementationSpecificOptions{})
 	if len(errs) > 0 {
 		return i2gw.GatewayResources{}, errs
 	}
 
 	for _, parseFeatureFunc := range c.featureParsers {
 		// Apply the feature parsing function to the gateway resources, one by one.
-		parseErrs := parseFeatureFunc(resources, &gatewayResources)
+		parseErrs := parseFeatureFunc(i2gw.InputResources{Ingresses: ingressList}, &gatewayResources)
 		// Append the parsing errors to the error list.
 		errs = append(errs, parseErrs...)
 	}

--- a/pkg/i2gw/providers/ingressnginx/ingressnginx.go
+++ b/pkg/i2gw/providers/ingressnginx/ingressnginx.go
@@ -17,11 +17,16 @@ limitations under the License.
 package ingressnginx
 
 import (
+	"context"
+	"fmt"
+
 	"github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
 // The Name of the provider.
 const Name = "ingress-nginx"
+const NginxIngressClass = "nginx"
 
 func init() {
 	i2gw.ProviderConstructorByName[Name] = NewProvider
@@ -29,17 +34,42 @@ func init() {
 
 // Provider implements the i2gw.Provider interface.
 type Provider struct {
-	conf *i2gw.ProviderConf
-
-	*resourceReader
-	*converter
+	storage        *storage
+	resourceReader *resourceReader
+	converter      *converter
 }
 
 // NewProvider constructs and returns the ingress-nginx implementation of i2gw.Provider.
 func NewProvider(conf *i2gw.ProviderConf) i2gw.Provider {
 	return &Provider{
-		conf:           conf,
+		storage:        newResourcesStorage(),
 		resourceReader: newResourceReader(conf),
-		converter:      newConverter(conf),
+		converter:      newConverter(),
 	}
+}
+
+// ToGatewayAPI converts the received i2gw.InputResources to i2gw.GatewayResources
+// including the ingress-nginx specific features.
+func (p *Provider) ToGatewayAPI(_ i2gw.InputResources) (i2gw.GatewayResources, field.ErrorList) {
+	return p.converter.convert(p.storage)
+}
+
+func (p *Provider) ReadResourcesFromCluster(ctx context.Context) error {
+	storage, err := p.resourceReader.readResourcesFromCluster(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to read resources from cluster: %w", err)
+	}
+
+	p.storage = storage
+	return nil
+}
+
+func (p *Provider) ReadResourcesFromFile(ctx context.Context, filename string) error {
+	storage, err := p.resourceReader.readResourcesFromFile(ctx, filename)
+	if err != nil {
+		return fmt.Errorf("failed to read resources from file: %w", err)
+	}
+
+	p.storage = storage
+	return nil
 }

--- a/pkg/i2gw/providers/ingressnginx/resource_reader.go
+++ b/pkg/i2gw/providers/ingressnginx/resource_reader.go
@@ -17,9 +17,16 @@ limitations under the License.
 package ingressnginx
 
 import (
+	"bytes"
 	"context"
+	"fmt"
+	"os"
 
 	"github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw"
+	"github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw/providers/common"
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // converter implements the i2gw.CustomResourceReader interface.
@@ -34,12 +41,51 @@ func newResourceReader(conf *i2gw.ProviderConf) *resourceReader {
 	}
 }
 
-func (r *resourceReader) ReadResourcesFromCluster(_ context.Context) error {
-	// ingress-nginx does not have any CRDs.
-	return nil
+func (r *resourceReader) readResourcesFromCluster(ctx context.Context) (*storage, error) {
+	storage := newResourcesStorage()
+
+	var ingressList networkingv1.IngressList
+	err := r.conf.Client.List(ctx, &ingressList)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get ingresses from the cluster: %w", err)
+	}
+
+	for i, ingress := range ingressList.Items {
+		if common.GetIngressClass(ingress) != NginxIngressClass {
+			continue
+		}
+		storage.Ingresses[types.NamespacedName{Namespace: ingress.Namespace, Name: ingress.Name}] = &ingressList.Items[i]
+	}
+
+	return storage, nil
 }
 
-func (r *resourceReader) ReadResourcesFromFile(_ context.Context, _ string) error {
-	// ingress-nginx does not have any CRDs.
-	return nil
+func (r *resourceReader) readResourcesFromFile(_ context.Context, filename string) (*storage, error) {
+	storage := newResourcesStorage()
+	stream, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read file %v: %w", filename, err)
+	}
+
+	unstructuredObjects, err := i2gw.ExtractObjectsFromReader(bytes.NewReader(stream), r.conf.Namespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract objects: %w", err)
+	}
+
+	for _, f := range unstructuredObjects {
+		if !f.GroupVersionKind().Empty() && f.GroupVersionKind().Kind == "Ingress" {
+			var i networkingv1.Ingress
+			err = runtime.DefaultUnstructuredConverter.
+				FromUnstructured(f.UnstructuredContent(), &i)
+			if err != nil {
+				return nil, err
+			}
+			if common.GetIngressClass(i) != NginxIngressClass {
+				continue
+			}
+			storage.Ingresses[types.NamespacedName{Namespace: i.Namespace, Name: i.Name}] = &i
+		}
+
+	}
+	return storage, nil
 }

--- a/pkg/i2gw/providers/ingressnginx/storage.go
+++ b/pkg/i2gw/providers/ingressnginx/storage.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ingressnginx
+
+import (
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+type storage struct {
+	Ingresses map[types.NamespacedName]*networkingv1.Ingress
+}
+
+func newResourcesStorage() *storage {
+	return &storage{
+		Ingresses: map[types.NamespacedName]*networkingv1.Ingress{},
+	}
+}

--- a/pkg/i2gw/providers/istio/istio.go
+++ b/pkg/i2gw/providers/istio/istio.go
@@ -17,10 +17,8 @@ limitations under the License.
 package istio
 
 import (
-	"bytes"
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -43,7 +41,7 @@ type Provider struct {
 func NewProvider(conf *i2gw.ProviderConf) i2gw.Provider {
 	return &Provider{
 		storage:   newResourcesStorage(),
-		reader:    newResourceReader(conf.Client),
+		reader:    newResourceReader(conf),
 		converter: newConverter(),
 	}
 }
@@ -66,22 +64,11 @@ func (p *Provider) ReadResourcesFromCluster(ctx context.Context) error {
 	return nil
 }
 
-func (p *Provider) ReadResourcesFromFile(_ context.Context, filename string) error {
-	stream, err := os.ReadFile(filename)
+func (p *Provider) ReadResourcesFromFile(ctx context.Context, filename string) error {
+	storage, err := p.reader.readResourcesFromFile(ctx, filename)
 	if err != nil {
-		return fmt.Errorf("failed to read file %v: %w", filename, err)
+		return fmt.Errorf("failed to read resources from file: %w", err)
 	}
-
-	unstructuredObjects, err := i2gw.ExtractObjectsFromReader(bytes.NewReader(stream))
-	if err != nil {
-		return fmt.Errorf("failed to extract objects: %w", err)
-	}
-
-	storage, err := p.reader.readUnstructuredObjects(unstructuredObjects)
-	if err != nil {
-		return fmt.Errorf("failed to read unstructured objects: %w", err)
-	}
-
 	p.storage = *storage
 	return nil
 }

--- a/pkg/i2gw/providers/kong/converter.go
+++ b/pkg/i2gw/providers/kong/converter.go
@@ -19,21 +19,19 @@ package kong
 import (
 	"github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw"
 	"github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw/providers/common"
+	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
 // converter implements the ToGatewayAPI function of i2gw.ResourceConverter interface.
 type converter struct {
-	conf *i2gw.ProviderConf
-
 	featureParsers                []i2gw.FeatureParser
 	implementationSpecificOptions i2gw.ProviderImplementationSpecificOptions
 }
 
 // newConverter returns an kong converter instance.
-func newConverter(conf *i2gw.ProviderConf) *converter {
+func newConverter() *converter {
 	return &converter{
-		conf: conf,
 		featureParsers: []i2gw.FeatureParser{
 			headerMatchingFeature,
 			methodMatchingFeature,
@@ -45,23 +43,24 @@ func newConverter(conf *i2gw.ProviderConf) *converter {
 	}
 }
 
-// ToGatewayAPI converts the received i2gw.InputResources to i2gw.GatewayResources
-// including the kong specific features.
-func (c *converter) ToGatewayAPI(resources i2gw.InputResources) (i2gw.GatewayResources, field.ErrorList) {
+func (c *converter) convert(storage *storage) (i2gw.GatewayResources, field.ErrorList) {
+	ingressList := []networkingv1.Ingress{}
+	for _, ing := range storage.Ingresses {
+		ingressList = append(ingressList, *ing)
+	}
 
 	// Convert plain ingress resources to gateway resources, ignoring all
 	// provider-specific features.
-	gatewayResources, errs := common.ToGateway(resources.Ingresses, c.implementationSpecificOptions)
+	gatewayResources, errs := common.ToGateway(ingressList, c.implementationSpecificOptions)
 	if len(errs) > 0 {
 		return i2gw.GatewayResources{}, errs
 	}
 
 	for _, parseFeatureFunc := range c.featureParsers {
 		// Apply the feature parsing function to the gateway resources, one by one.
-		parseErrs := parseFeatureFunc(resources, &gatewayResources)
+		parseErrs := parseFeatureFunc(i2gw.InputResources{Ingresses: ingressList}, &gatewayResources)
 		// Append the parsing errors to the error list.
 		errs = append(errs, parseErrs...)
 	}
-
 	return gatewayResources, errs
 }

--- a/pkg/i2gw/providers/kong/converter_test.go
+++ b/pkg/i2gw/providers/kong/converter_test.go
@@ -39,14 +39,14 @@ func Test_ToGateway(t *testing.T) {
 
 	testCases := []struct {
 		name                     string
-		ingresses                []networkingv1.Ingress
+		ingresses                map[types.NamespacedName]*networkingv1.Ingress
 		expectedGatewayResources i2gw.GatewayResources
 		expectedErrors           field.ErrorList
 	}{
 		{
 			name: "header matching, method matching, plugin, single ingress rule",
-			ingresses: []networkingv1.Ingress{
-				{
+			ingresses: map[types.NamespacedName]*networkingv1.Ingress{
+				{Namespace: "default", Name: "multiple-matching-single-rule"}: {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "multiple-matching-single-rule",
 						Namespace: "default",
@@ -163,8 +163,8 @@ func Test_ToGateway(t *testing.T) {
 		},
 		{
 			name: "header matching, method matching, multiple ingress rules",
-			ingresses: []networkingv1.Ingress{
-				{
+			ingresses: map[types.NamespacedName]*networkingv1.Ingress{
+				{Namespace: "default", Name: "multiple-matching-multiple-rules"}: {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "multiple-matching-multiple-rules",
 						Namespace: "default",
@@ -326,8 +326,8 @@ func Test_ToGateway(t *testing.T) {
 		},
 		{
 			name: "ImplementationSpecific HTTPRouteMatching with regex",
-			ingresses: []networkingv1.Ingress{
-				{
+			ingresses: map[types.NamespacedName]*networkingv1.Ingress{
+				{Namespace: "default", Name: "implementation-specific-regex"}: {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "implementation-specific-regex",
 						Namespace: "default",
@@ -411,8 +411,8 @@ func Test_ToGateway(t *testing.T) {
 		},
 		{
 			name: "ImplementationSpecific HTTPRouteMatching without regex",
-			ingresses: []networkingv1.Ingress{
-				{
+			ingresses: map[types.NamespacedName]*networkingv1.Ingress{
+				{Namespace: "default", Name: "implementation-no-regex"}: {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "implementation-specific-no-regex",
 						Namespace: "default",
@@ -500,12 +500,11 @@ func Test_ToGateway(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 
 			provider := NewProvider(&i2gw.ProviderConf{})
+			kongProvider := provider.(*Provider)
+			kongProvider.storage.Ingresses = tc.ingresses
 
-			resources := i2gw.InputResources{
-				Ingresses: tc.ingresses,
-			}
-
-			gatewayResources, errs := provider.ToGatewayAPI(resources)
+			// TODO(#113) we pass an empty i2gw.InputResources temporarily until we change ToGatewayAPI function on the interface
+			gatewayResources, errs := provider.ToGatewayAPI(i2gw.InputResources{})
 
 			if len(gatewayResources.HTTPRoutes) != len(tc.expectedGatewayResources.HTTPRoutes) {
 				t.Errorf("Expected %d HTTPRoutes, got %d: %+v",

--- a/pkg/i2gw/providers/kong/kong.go
+++ b/pkg/i2gw/providers/kong/kong.go
@@ -17,11 +17,16 @@ limitations under the License.
 package kong
 
 import (
+	"context"
+	"fmt"
+
 	"github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
 // The Name of the provider.
 const Name = "kong"
+const KongIngressClass = "kong"
 
 func init() {
 	i2gw.ProviderConstructorByName[Name] = NewProvider
@@ -29,17 +34,42 @@ func init() {
 
 // Provider implements the i2gw.Provider interface.
 type Provider struct {
-	conf *i2gw.ProviderConf
-
-	*resourceReader
-	*converter
+	storage        *storage
+	resourceReader *resourceReader
+	converter      *converter
 }
 
 // NewProvider constructs and returns the kong implementation of i2gw.Provider.
 func NewProvider(conf *i2gw.ProviderConf) i2gw.Provider {
 	return &Provider{
-		conf:           conf,
+		storage:        newResourcesStorage(),
 		resourceReader: newResourceReader(conf),
-		converter:      newConverter(conf),
+		converter:      newConverter(),
 	}
+}
+
+// ToGatewayAPI converts the received i2gw.InputResources to i2gw.GatewayResources
+// including the kong specific features.
+func (p *Provider) ToGatewayAPI(_ i2gw.InputResources) (i2gw.GatewayResources, field.ErrorList) {
+	return p.converter.convert(p.storage)
+}
+
+func (p *Provider) ReadResourcesFromCluster(ctx context.Context) error {
+	storage, err := p.resourceReader.readResourcesFromCluster(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to read resources from cluster: %w", err)
+	}
+
+	p.storage = storage
+	return nil
+}
+
+func (p *Provider) ReadResourcesFromFile(ctx context.Context, filename string) error {
+	storage, err := p.resourceReader.readResourcesFromFile(ctx, filename)
+	if err != nil {
+		return fmt.Errorf("failed to read resources from file: %w", err)
+	}
+
+	p.storage = storage
+	return nil
 }

--- a/pkg/i2gw/providers/kong/resource_reader.go
+++ b/pkg/i2gw/providers/kong/resource_reader.go
@@ -17,9 +17,16 @@ limitations under the License.
 package kong
 
 import (
+	"bytes"
 	"context"
+	"fmt"
+	"os"
 
 	"github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw"
+	"github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw/providers/common"
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // converter implements the i2gw.CustomResourceReader interface.
@@ -34,10 +41,51 @@ func newResourceReader(conf *i2gw.ProviderConf) *resourceReader {
 	}
 }
 
-func (r *resourceReader) ReadResourcesFromCluster(_ context.Context) error {
-	return nil
+func (r *resourceReader) readResourcesFromCluster(ctx context.Context) (*storage, error) {
+	storage := newResourcesStorage()
+
+	var ingressList networkingv1.IngressList
+	err := r.conf.Client.List(ctx, &ingressList)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get ingresses from the cluster: %w", err)
+	}
+
+	for i, ingress := range ingressList.Items {
+		if common.GetIngressClass(ingress) != KongIngressClass {
+			continue
+		}
+		storage.Ingresses[types.NamespacedName{Namespace: ingress.Namespace, Name: ingress.Name}] = &ingressList.Items[i]
+	}
+
+	return storage, nil
 }
 
-func (r *resourceReader) ReadResourcesFromFile(_ context.Context, _ string) error {
-	return nil
+func (r *resourceReader) readResourcesFromFile(_ context.Context, filename string) (*storage, error) {
+	storage := newResourcesStorage()
+	stream, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read file %v: %w", filename, err)
+	}
+
+	unstructuredObjects, err := i2gw.ExtractObjectsFromReader(bytes.NewReader(stream), r.conf.Namespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract objects: %w", err)
+	}
+
+	for _, f := range unstructuredObjects {
+		if !f.GroupVersionKind().Empty() && f.GroupVersionKind().Kind == "Ingress" {
+			var i networkingv1.Ingress
+			err = runtime.DefaultUnstructuredConverter.
+				FromUnstructured(f.UnstructuredContent(), &i)
+			if err != nil {
+				return nil, err
+			}
+			if common.GetIngressClass(i) != KongIngressClass {
+				continue
+			}
+			storage.Ingresses[types.NamespacedName{Namespace: i.Namespace, Name: i.Name}] = &i
+		}
+
+	}
+	return storage, nil
 }

--- a/pkg/i2gw/providers/kong/storage.go
+++ b/pkg/i2gw/providers/kong/storage.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kong
+
+import (
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+type storage struct {
+	Ingresses map[types.NamespacedName]*networkingv1.Ingress
+}
+
+func newResourcesStorage() *storage {
+	return &storage{
+		Ingresses: map[types.NamespacedName]*networkingv1.Ingress{},
+	}
+}


### PR DESCRIPTION
Reverts kubernetes-sigs/ingress2gateway#114 which is the revert of kubernetes-sigs/ingress2gateway#112

Better to review kubernetes-sigs/ingress2gateway#112 instead as the commits there are structured and easy the review so you could review each commit independently

I copy pasted the below PR description from kubernetes-sigs/ingress2gateway#112

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Currently we fetch all the ingresses in the main package and we pass them to all the providers. 

This is not only redundant (as every provider only cares about its own ingresses) but also creates some bugs. (https://github.com/kubernetes-sigs/ingress2gateway/issues/109)

This also increases consistency as we already fetch CRDs at the provider level and store them in a local storage.

Note: This PR is likely to yield some more issues and TODOs that wont be addressed in this PR.
For example changing `ToGatewayAPI` interface function signature that wont need `i2gw.InputResources` anymore.
Another thing would be to revisit `i2gw.InputResources` struct and check if we need it or we will change it to just a list of Ingresses as it is the only things it holds now.

I structured the commits to ease the review so you could review each commit independently

**Which issue(s) this PR fixes**:
Fixes #109 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Move ingress fetching logic to be isolated, per provider
```
