### PR TITLE
Skip k8s client creation when reading local file.

### DIFF
--- a/pkg/i2gw/ingress2gateway.go
+++ b/pkg/i2gw/ingress2gateway.go
@@ -26,19 +26,23 @@ import (
 )
 
 func ToGatewayAPIResources(ctx context.Context, namespace string, inputFile string, providers []string) ([]GatewayResources, error) {
-	conf, err := config.GetConfig()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get client config: %w", err)
-	}
+	var clusterClient client.Client
 
-	cl, err := client.New(conf, client.Options{})
-	if err != nil {
-		return nil, fmt.Errorf("failed to create client: %w", err)
+	if inputFile == "" {
+		conf, err := config.GetConfig()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get client config: %w", err)
+		}
+
+		cl, err := client.New(conf, client.Options{})
+		if err != nil {
+			return nil, fmt.Errorf("failed to create client: %w", err)
+		}
+		clusterClient = client.NewNamespacedClient(cl, namespace)
 	}
-	cl = client.NewNamespacedClient(cl, namespace)
 
 	providerByName, err := constructProviders(&ProviderConf{
-		Client:    cl,
+		Client:    clusterClient,
 		Namespace: namespace,
 	}, providers)
 	if err != nil {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Make the tool more robust. Don't read/run k8s client config when reading local file. E.g. user may have incorrect/incompatible .kube_config but the user tries to convert a local file. `.kube_config` file should not affect the tool run in such case.

I've checked all providers, none needs a k8sclient to translate a local file, which is expected.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #127

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Skip k8s client creation when reading local file.
```
