### PR TITLE
feat: add a kubeconfig flag to specify kubeconfig file location

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,13 +61,14 @@ This above command will:
 
 ### `print` command
 
-| Flag           | Default Value           | Required | Description                                                                                                                                                                             |
-| -------------- | ----------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| namespace      |                         | No       | If present, the namespace scope for the invocation                                                                                                                                      |
-| all-namespaces | False                   | No       | If present, list the requested object(s) across all namespaces. Namespace in the current context is ignored even if specified with --namespace                                          |
-| output         | yaml                    | No       | The output format, either yaml or json                                                                                                                                                  |
-| input_file     |                         | No       | Path to the manifest file. When set, the tool will read ingresses from the file instead of reading from the cluster. Supported files are yaml and json                                  |
+| Flag           | Default Value           | Required | Description                                                  |
+| -------------- | ----------------------- | -------- | ------------------------------------------------------------ |
+| namespace      |                         | No       | If present, the namespace scope for the invocation           |
+| all-namespaces | False                   | No       | If present, list the requested object(s) across all namespaces. Namespace in the current context is ignored even if specified with --namespace |
+| output         | yaml                    | No       | The output format, either yaml or json                       |
+| input_file     |                         | No       | Path to the manifest file. When set, the tool will read ingresses from the file instead of reading from the cluster. Supported files are yaml and json |
 | providers      | all supported providers | No       | Comma-separated list of providers. If present, the tool will try to convert only resources related to the specified providers. Otherwise it will default to all the supported providers |
+| kubeconfig     |                         | No       | The kubeconfig file to use when talking to the cluster. If the flag is not set, a set of standard locations can be searched for an existing kubeconfig file. |
 
 ## Conversion of Ingress resources to Gateway API
 

--- a/cmd/print.go
+++ b/cmd/print.go
@@ -261,7 +261,3 @@ func getNamespaceInCurrentContext() (string, error) {
 
 	return currentNamespace, err
 }
-
-func init() {
-	rootCmd.AddCommand(newPrintCommand())
-}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,12 +22,32 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var rootCmd = &cobra.Command{
-	Use:   "ingress2gateway",
-	Short: "Convert Ingress manifests to Gateway API manifests",
+// kubeconfig indicates kubeconfig file location.
+var kubeconfig string
+
+func newRootCmd() *cobra.Command {
+	rootCmd := &cobra.Command{
+		Use:   "ingress2gateway",
+		Short: "Convert Ingress manifests to Gateway API manifests",
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			getKubeconfig()
+		},
+	}
+
+	rootCmd.PersistentFlags().StringVar(&kubeconfig, "kubeconfig", "",
+		`The kubeconfig file to use when talking to the cluster. If the flag is not set, a set of standard locations can be searched for an existing kubeconfig file.`)
+	return rootCmd
+}
+
+func getKubeconfig() {
+	if kubeconfig != "" {
+		os.Setenv("KUBECONFIG", kubeconfig)
+	}
 }
 
 func Execute() {
+	rootCmd := newRootCmd()
+	rootCmd.AddCommand(newPrintCommand())
 	err := rootCmd.Execute()
 	if err != nil {
 		os.Exit(1)


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/ingress2gateway/blob/main/CONTRIBUTING.md). -->

<!-- The release notes and the kind will be used to generate the Changelog for the release. To make sure your contribution is recognized, please label this pull request according to what type of issue you are addressing and add the release notes when necessary (see ../CONTRIBUTING.md) -->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Some users and organizations work with multiple Kubernetes clusters by utilizing multiple config files instead of one. The `--kubeconfig` flag allows you to switch between these clusters by specifying different configuration files.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #81 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Add a `--kubeconfig` flag to specify kubeconfig file location 
```
