### PR TITLE
fix: weight can not set to 0

### DIFF
--- a/pkg/i2gw/providers/ingressnginx/canary.go
+++ b/pkg/i2gw/providers/ingressnginx/canary.go
@@ -127,7 +127,7 @@ func calculateBackendRefWeight(paths []ingressPath) ([]gatewayv1.HTTPBackendRef,
 			errors = append(errors, err)
 			continue
 		}
-		if path.extra != nil && path.extra.canary != nil && path.extra.canary.weight != 0 {
+		if path.extra != nil && path.extra.canary != nil && path.extra.canary.enable == true {
 			weight := int32(path.extra.canary.weight)
 			backendRef.Weight = &weight
 			totalWeightSet += weight

--- a/pkg/i2gw/providers/ingressnginx/canary.go
+++ b/pkg/i2gw/providers/ingressnginx/canary.go
@@ -127,7 +127,7 @@ func calculateBackendRefWeight(paths []ingressPath) ([]gatewayv1.HTTPBackendRef,
 			errors = append(errors, err)
 			continue
 		}
-		if path.extra != nil && path.extra.canary != nil && path.extra.canary.enable == true {
+		if path.extra != nil && path.extra.canary != nil && path.extra.canary.enable {
 			weight := int32(path.extra.canary.weight)
 			backendRef.Weight = &weight
 			totalWeightSet += weight

--- a/pkg/i2gw/providers/ingressnginx/canary_test.go
+++ b/pkg/i2gw/providers/ingressnginx/canary_test.go
@@ -105,6 +105,76 @@ func Test_ingressRuleGroup_calculateBackendRefWeight(t *testing.T) {
 			},
 		},
 		{
+			name: "set weight as 0",
+			paths: []ingressPath{
+				{
+					path: networkingv1.HTTPIngressPath{
+						Backend: networkingv1.IngressBackend{
+							Resource: &corev1.TypedLocalObjectReference{
+								Name:     "canary",
+								Kind:     "StorageBucket",
+								APIGroup: ptrTo("vendor.example.com"),
+							},
+						},
+					},
+					extra: &extra{canary: &canaryAnnotations{
+						enable: true,
+						weight: 0,
+					}},
+				},
+				{
+					path: networkingv1.HTTPIngressPath{
+						Backend: networkingv1.IngressBackend{
+							Resource: &corev1.TypedLocalObjectReference{
+								Name:     "prod",
+								Kind:     "StorageBucket",
+								APIGroup: ptrTo("vendor.example.com"),
+							},
+						},
+					},
+				},
+			},
+			expectedBackendRefs: []gatewayv1.HTTPBackendRef{
+				{BackendRef: gatewayv1.BackendRef{Weight: ptrTo(int32(0))}},
+				{BackendRef: gatewayv1.BackendRef{Weight: ptrTo(int32(100))}},
+			},
+		},
+		{
+			name: "set weight as 100",
+			paths: []ingressPath{
+				{
+					path: networkingv1.HTTPIngressPath{
+						Backend: networkingv1.IngressBackend{
+							Resource: &corev1.TypedLocalObjectReference{
+								Name:     "canary",
+								Kind:     "StorageBucket",
+								APIGroup: ptrTo("vendor.example.com"),
+							},
+						},
+					},
+					extra: &extra{canary: &canaryAnnotations{
+						enable: true,
+						weight: 100,
+					}},
+				},
+				{
+					path: networkingv1.HTTPIngressPath{
+						Backend: networkingv1.IngressBackend{
+							Resource: &corev1.TypedLocalObjectReference{
+								Name:     "prod",
+								Kind:     "StorageBucket",
+								APIGroup: ptrTo("vendor.example.com"),
+							},
+						},
+					},
+				},
+			},
+			expectedBackendRefs: []gatewayv1.HTTPBackendRef{
+				{BackendRef: gatewayv1.BackendRef{Weight: ptrTo(int32(100))}},
+				{BackendRef: gatewayv1.BackendRef{Weight: ptrTo(int32(0))}},
+			},
+		},
+		{
 			name: "weight total assigned",
 			paths: []ingressPath{
 				{

--- a/pkg/i2gw/providers/ingressnginx/canary_test.go
+++ b/pkg/i2gw/providers/ingressnginx/canary_test.go
@@ -48,6 +48,7 @@ func Test_ingressRuleGroup_calculateBackendRefWeight(t *testing.T) {
 						},
 					},
 					extra: &extra{canary: &canaryAnnotations{
+						enable: true,
 						weight: 101,
 					}},
 				},
@@ -82,6 +83,7 @@ func Test_ingressRuleGroup_calculateBackendRefWeight(t *testing.T) {
 						},
 					},
 					extra: &extra{canary: &canaryAnnotations{
+						enable: true,
 						weight: 30,
 					}},
 				},
@@ -116,6 +118,7 @@ func Test_ingressRuleGroup_calculateBackendRefWeight(t *testing.T) {
 						},
 					},
 					extra: &extra{canary: &canaryAnnotations{
+						enable:      true,
 						weight:      50,
 						weightTotal: 200,
 					}},


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/ingress2gateway/blob/main/CONTRIBUTING.md). -->

<!-- The release notes and the kind will be used to generate the Changelog for the release. To make sure your contribution is recognized, please label this pull request according to what type of issue you are addressing and add the release notes when necessary (see ../CONTRIBUTING.md) -->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug
**What this PR does / why we need it**:

Fixed the issue where canary weight cannot be set to 0.
During testing or debugging, it is common practice to temporarily set the weight of a specific backend to 0 but it is not supported currently in this project

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #136 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Add translation when canary-weight is set to 0
```
