### PR TITLE
fix flakly ingressnginx test

### DIFF
--- a/pkg/i2gw/providers/ingressnginx/converter.go
+++ b/pkg/i2gw/providers/ingressnginx/converter.go
@@ -19,7 +19,6 @@ package ingressnginx
 import (
 	"github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw"
 	"github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw/providers/common"
-	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
@@ -40,10 +39,7 @@ func newConverter() *converter {
 func (c *converter) convert(storage *storage) (i2gw.GatewayResources, field.ErrorList) {
 
 	// TODO(liorliberman) temporary until we decide to change ToGateway and featureParsers to get a map of [types.NamespacedName]*networkingv1.Ingress instead of a list
-	ingressList := []networkingv1.Ingress{}
-	for _, ing := range storage.Ingresses.ingressNames {
-		ingressList = append(ingressList, *storage.Ingresses.ingressObjects[ing])
-	}
+	ingressList := storage.Ingresses.List()
 
 	// Convert plain ingress resources to gateway resources, ignoring all
 	// provider-specific features.

--- a/pkg/i2gw/providers/ingressnginx/converter.go
+++ b/pkg/i2gw/providers/ingressnginx/converter.go
@@ -41,8 +41,8 @@ func (c *converter) convert(storage *storage) (i2gw.GatewayResources, field.Erro
 
 	// TODO(liorliberman) temporary until we decide to change ToGateway and featureParsers to get a map of [types.NamespacedName]*networkingv1.Ingress instead of a list
 	ingressList := []networkingv1.Ingress{}
-	for _, ing := range storage.Ingresses {
-		ingressList = append(ingressList, *ing)
+	for _, ing := range storage.Ingresses.ingressNames {
+		ingressList = append(ingressList, *storage.Ingresses.ingressObjects[ing])
 	}
 
 	// Convert plain ingress resources to gateway resources, ignoring all

--- a/pkg/i2gw/providers/ingressnginx/resource_reader.go
+++ b/pkg/i2gw/providers/ingressnginx/resource_reader.go
@@ -18,11 +18,9 @@ package ingressnginx
 
 import (
 	"context"
-	"sort"
 
 	"github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw"
 	"github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw/providers/common"
-	"k8s.io/apimachinery/pkg/types"
 )
 
 // converter implements the i2gw.CustomResourceReader interface.
@@ -44,14 +42,7 @@ func (r *resourceReader) readResourcesFromCluster(ctx context.Context) (*storage
 	if err != nil {
 		return nil, err
 	}
-	ingNames := []types.NamespacedName{}
-	for ing := range ingresses {
-		ingNames = append(ingNames, ing)
-	}
-	sort.Slice(ingNames, func(i, j int) bool {
-		return ingNames[i].Name < ingNames[j].Name
-	})
-	storage.Ingresses = OrderedIngressMap{ingressNames: ingNames, ingressObjects: ingresses}
+	storage.Ingresses.FromMap(ingresses)
 	return storage, nil
 }
 
@@ -62,13 +53,6 @@ func (r *resourceReader) readResourcesFromFile(filename string) (*storage, error
 	if err != nil {
 		return nil, err
 	}
-	ingNames := []types.NamespacedName{}
-	for ing := range ingresses {
-		ingNames = append(ingNames, ing)
-	}
-	sort.Slice(ingNames, func(i, j int) bool {
-		return ingNames[i].Name < ingNames[j].Name
-	})
-	storage.Ingresses = OrderedIngressMap{ingressNames: ingNames, ingressObjects: ingresses}
+	storage.Ingresses.FromMap(ingresses)
 	return storage, nil
 }

--- a/pkg/i2gw/providers/ingressnginx/resource_reader.go
+++ b/pkg/i2gw/providers/ingressnginx/resource_reader.go
@@ -18,9 +18,11 @@ package ingressnginx
 
 import (
 	"context"
+	"sort"
 
 	"github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw"
 	"github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw/providers/common"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // converter implements the i2gw.CustomResourceReader interface.
@@ -42,7 +44,14 @@ func (r *resourceReader) readResourcesFromCluster(ctx context.Context) (*storage
 	if err != nil {
 		return nil, err
 	}
-	storage.Ingresses = ingresses
+	ingNames := []types.NamespacedName{}
+	for ing := range ingresses {
+		ingNames = append(ingNames, ing)
+	}
+	sort.Slice(ingNames, func(i, j int) bool {
+		return ingNames[i].Name < ingNames[j].Name
+	})
+	storage.Ingresses = OrderedIngressMap{ingressNames: ingNames, ingressObjects: ingresses}
 	return storage, nil
 }
 
@@ -53,6 +62,13 @@ func (r *resourceReader) readResourcesFromFile(filename string) (*storage, error
 	if err != nil {
 		return nil, err
 	}
-	storage.Ingresses = ingresses
+	ingNames := []types.NamespacedName{}
+	for ing := range ingresses {
+		ingNames = append(ingNames, ing)
+	}
+	sort.Slice(ingNames, func(i, j int) bool {
+		return ingNames[i].Name < ingNames[j].Name
+	})
+	storage.Ingresses = OrderedIngressMap{ingressNames: ingNames, ingressObjects: ingresses}
 	return storage, nil
 }

--- a/pkg/i2gw/providers/ingressnginx/storage.go
+++ b/pkg/i2gw/providers/ingressnginx/storage.go
@@ -21,12 +21,19 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
+type OrderedIngressMap struct {
+	ingressNames   []types.NamespacedName
+	ingressObjects map[types.NamespacedName]*networkingv1.Ingress
+}
 type storage struct {
-	Ingresses map[types.NamespacedName]*networkingv1.Ingress
+	Ingresses OrderedIngressMap
 }
 
 func newResourcesStorage() *storage {
 	return &storage{
-		Ingresses: map[types.NamespacedName]*networkingv1.Ingress{},
+		Ingresses: OrderedIngressMap{
+			ingressNames:   []types.NamespacedName{},
+			ingressObjects: map[types.NamespacedName]*networkingv1.Ingress{},
+		},
 	}
 }

--- a/pkg/i2gw/providers/ingressnginx/storage.go
+++ b/pkg/i2gw/providers/ingressnginx/storage.go
@@ -17,6 +17,8 @@ limitations under the License.
 package ingressnginx
 
 import (
+	"sort"
+
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -36,4 +38,24 @@ func newResourcesStorage() *storage {
 			ingressObjects: map[types.NamespacedName]*networkingv1.Ingress{},
 		},
 	}
+}
+
+func (oim *OrderedIngressMap) List() []networkingv1.Ingress {
+	ingressList := []networkingv1.Ingress{}
+	for _, ing := range oim.ingressNames {
+		ingressList = append(ingressList, *oim.ingressObjects[ing])
+	}
+	return ingressList
+}
+
+func (oim *OrderedIngressMap) FromMap(ingresses map[types.NamespacedName]*networkingv1.Ingress) {
+	ingNames := []types.NamespacedName{}
+	for ing := range ingresses {
+		ingNames = append(ingNames, ing)
+	}
+	sort.Slice(ingNames, func(i, j int) bool {
+		return ingNames[i].Name < ingNames[j].Name
+	})
+	oim.ingressNames = ingNames
+	oim.ingressObjects = ingresses
 }


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/ingress2gateway/blob/main/CONTRIBUTING.md). -->

<!-- The release notes and the kind will be used to generate the Changelog for the release. To make sure your contribution is recognized, please label this pull request according to what type of issue you are addressing and add the release notes when necessary (see ../CONTRIBUTING.md) -->

**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
Ingress-nginx support mergind different ingresses to one HTTPRoute, but since we used a map to store the ingresses, the order is not consistent, causing tests to be flaky
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Fixed ingress-nginx conversion tests
```

/cc @levikobi 
FYI @YTGhost
