### PR TITLE
feat: deprecate i2gw.InputResources

### DIFF
--- a/pkg/i2gw/ingress2gateway.go
+++ b/pkg/i2gw/ingress2gateway.go
@@ -68,8 +68,7 @@ func ToGatewayAPIResources(ctx context.Context, namespace string, inputFile stri
 		errs             field.ErrorList
 	)
 	for _, provider := range providerByName {
-		// TODO(#113) Remove input resources from ToGatewayAPI function
-		providerGatewayResources, conversionErrs := provider.ToGatewayAPI(InputResources{})
+		providerGatewayResources, conversionErrs := provider.ToGatewayAPI()
 		errs = append(errs, conversionErrs...)
 		gatewayResources = append(gatewayResources, providerGatewayResources)
 	}

--- a/pkg/i2gw/provider.go
+++ b/pkg/i2gw/provider.go
@@ -69,9 +69,9 @@ type CustomResourceReader interface {
 // conversion functions.
 type ResourceConverter interface {
 
-	// ToGatewayAPIResources converts the received InputResources associated
+	// ToGatewayAPIResources converts stored API entities associated
 	// with the Provider into GatewayResources.
-	ToGatewayAPI(resources InputResources) (GatewayResources, field.ErrorList)
+	ToGatewayAPI() (GatewayResources, field.ErrorList)
 }
 
 // ImplementationSpecificHTTPPathTypeMatchConverter is an option to customize the ingress implementationSpecific
@@ -83,11 +83,6 @@ type ImplementationSpecificHTTPPathTypeMatchConverter func(*gatewayv1.HTTPPathMa
 // implementation-specific fields of the ingress API.
 type ProviderImplementationSpecificOptions struct {
 	ToImplementationSpecificHTTPPathTypeMatch ImplementationSpecificHTTPPathTypeMatchConverter
-}
-
-// InputResources contains all Ingress objects.
-type InputResources struct {
-	Ingresses []networkingv1.Ingress
 }
 
 // GatewayResources contains all Gateway-API objects.
@@ -103,9 +98,9 @@ type GatewayResources struct {
 	ReferenceGrants map[types.NamespacedName]gatewayv1alpha2.ReferenceGrant
 }
 
-// FeatureParser is a function that reads the InputResources, and applies
+// FeatureParser is a function that reads the Ingresses, and applies
 // the appropriate modifications to the GatewayResources.
 //
 // Different FeatureParsers will run in undetermined order. The function must
 // modify / create only the required fields of the gateway resources and nothing else.
-type FeatureParser func(InputResources, *GatewayResources) field.ErrorList
+type FeatureParser func([]networkingv1.Ingress, *GatewayResources) field.ErrorList

--- a/pkg/i2gw/providers/apisix/apisix.go
+++ b/pkg/i2gw/providers/apisix/apisix.go
@@ -48,9 +48,9 @@ func NewProvider(conf *i2gw.ProviderConf) i2gw.Provider {
 	}
 }
 
-// ToGatewayAPI converts the received i2gw.InputResources to i2gw.GatewayResources
+// ToGatewayAPI converts stored Apisix API entities to i2gw.GatewayResources
 // including the apisix specific features.
-func (p *Provider) ToGatewayAPI(_ i2gw.InputResources) (i2gw.GatewayResources, field.ErrorList) {
+func (p *Provider) ToGatewayAPI() (i2gw.GatewayResources, field.ErrorList) {
 	return p.converter.convert(p.storage)
 }
 

--- a/pkg/i2gw/providers/apisix/converter.go
+++ b/pkg/i2gw/providers/apisix/converter.go
@@ -55,7 +55,7 @@ func (c *converter) convert(storage *storage) (i2gw.GatewayResources, field.Erro
 
 	for _, parseFeatureFunc := range c.featureParsers {
 		// Apply the feature parsing function to the gateway resources, one by one.
-		parseErrs := parseFeatureFunc(i2gw.InputResources{Ingresses: ingressList}, &gatewayResources)
+		parseErrs := parseFeatureFunc(ingressList, &gatewayResources)
 		// Append the parsing errors to the error list.
 		errs = append(errs, parseErrs...)
 	}

--- a/pkg/i2gw/providers/apisix/http_to_https.go
+++ b/pkg/i2gw/providers/apisix/http_to_https.go
@@ -19,16 +19,17 @@ package apisix
 import (
 	"github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw"
 	"github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw/providers/common"
+	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/ptr"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
-func httpToHTTPSFeature(ingressResources i2gw.InputResources, gatewayResources *i2gw.GatewayResources) field.ErrorList {
+func httpToHTTPSFeature(ingresses []networkingv1.Ingress, gatewayResources *i2gw.GatewayResources) field.ErrorList {
 	var errs field.ErrorList
 	httpToHTTPSAnnotation := apisixAnnotation("http-to-https")
-	ruleGroups := common.GetRuleGroups(ingressResources.Ingresses)
+	ruleGroups := common.GetRuleGroups(ingresses)
 	for _, rg := range ruleGroups {
 		for _, rule := range rg.Rules {
 			if val := rule.Ingress.Annotations[httpToHTTPSAnnotation]; val == "true" {

--- a/pkg/i2gw/providers/apisix/http_to_https_test.go
+++ b/pkg/i2gw/providers/apisix/http_to_https_test.go
@@ -257,16 +257,14 @@ func Test_httpToHttpsFeature(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ingressResources := i2gw.InputResources{
-				Ingresses: []networkingv1.Ingress{tc.ingress},
-			}
+			ingresses := []networkingv1.Ingress{tc.ingress}
 			gatewayResources := &i2gw.GatewayResources{
 				HTTPRoutes: map[types.NamespacedName]gatewayv1.HTTPRoute{
 					{Name: tc.expectedHTTPRoute.Name, Namespace: tc.expectedHTTPRoute.Namespace}: *tc.initialHTTPRoute,
 				},
 			}
 
-			errs := httpToHTTPSFeature(ingressResources, gatewayResources)
+			errs := httpToHTTPSFeature(ingresses, gatewayResources)
 
 			if len(errs) != len(tc.expectedError) {
 				t.Errorf("expected %d errors, got %d", len(tc.expectedError), len(errs))

--- a/pkg/i2gw/providers/ingressnginx/canary.go
+++ b/pkg/i2gw/providers/ingressnginx/canary.go
@@ -29,8 +29,8 @@ import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
-func canaryFeature(ingressResources i2gw.InputResources, gatewayResources *i2gw.GatewayResources) field.ErrorList {
-	ruleGroups := common.GetRuleGroups(ingressResources.Ingresses)
+func canaryFeature(ingresses []networkingv1.Ingress, gatewayResources *i2gw.GatewayResources) field.ErrorList {
+	ruleGroups := common.GetRuleGroups(ingresses)
 
 	for _, rg := range ruleGroups {
 		ingressPathsByMatchKey, errs := getPathsByMatchGroups(rg)

--- a/pkg/i2gw/providers/ingressnginx/converter.go
+++ b/pkg/i2gw/providers/ingressnginx/converter.go
@@ -54,7 +54,7 @@ func (c *converter) convert(storage *storage) (i2gw.GatewayResources, field.Erro
 
 	for _, parseFeatureFunc := range c.featureParsers {
 		// Apply the feature parsing function to the gateway resources, one by one.
-		parseErrs := parseFeatureFunc(i2gw.InputResources{Ingresses: ingressList}, &gatewayResources)
+		parseErrs := parseFeatureFunc(ingressList, &gatewayResources)
 		// Append the parsing errors to the error list.
 		errs = append(errs, parseErrs...)
 	}

--- a/pkg/i2gw/providers/ingressnginx/converter_test.go
+++ b/pkg/i2gw/providers/ingressnginx/converter_test.go
@@ -218,8 +218,7 @@ func Test_ToGateway(t *testing.T) {
 			nginxProvider := provider.(*Provider)
 			nginxProvider.storage.Ingresses = tc.ingresses
 
-			// TODO(#113) we pass an empty i2gw.InputResources temporarily until we change ToGatewayAPI function on the interface
-			gatewayResources, errs := provider.ToGatewayAPI(i2gw.InputResources{})
+			gatewayResources, errs := provider.ToGatewayAPI()
 
 			if len(errs) != len(tc.expectedErrors) {
 				t.Errorf("Expected %d errors, got %d: %+v", len(tc.expectedErrors), len(errs), errs)

--- a/pkg/i2gw/providers/ingressnginx/ingressnginx.go
+++ b/pkg/i2gw/providers/ingressnginx/ingressnginx.go
@@ -48,9 +48,9 @@ func NewProvider(conf *i2gw.ProviderConf) i2gw.Provider {
 	}
 }
 
-// ToGatewayAPI converts the received i2gw.InputResources to i2gw.GatewayResources
+// ToGatewayAPI converts stored Ingress-Nginx API entities to i2gw.GatewayResources
 // including the ingress-nginx specific features.
-func (p *Provider) ToGatewayAPI(_ i2gw.InputResources) (i2gw.GatewayResources, field.ErrorList) {
+func (p *Provider) ToGatewayAPI() (i2gw.GatewayResources, field.ErrorList) {
 	return p.converter.convert(p.storage)
 }
 

--- a/pkg/i2gw/providers/istio/e2e_file_converter_test.go
+++ b/pkg/i2gw/providers/istio/e2e_file_converter_test.go
@@ -55,7 +55,7 @@ func TestFileConversion(t *testing.T) {
 			t.Fatalf("Failed to read input from file %v: %v", d.Name(), err.Error())
 		}
 
-		gotGatewayResources, errList := istioProvider.ToGatewayAPI(i2gw.InputResources{})
+		gotGatewayResources, errList := istioProvider.ToGatewayAPI()
 		if len(errList) > 0 {
 			t.Fatalf("unexpected errors during input conversion for file %v: %v", d.Name(), errList.ToAggregate().Error())
 		}

--- a/pkg/i2gw/providers/istio/istio.go
+++ b/pkg/i2gw/providers/istio/istio.go
@@ -48,7 +48,7 @@ func NewProvider(conf *i2gw.ProviderConf) i2gw.Provider {
 
 // ToGatewayAPI converts stored Istio API entities to i2gw.GatewayResources
 // K8S Ingress resources are not needed, only Istio-based are converted
-func (p *Provider) ToGatewayAPI(_ i2gw.InputResources) (i2gw.GatewayResources, field.ErrorList) {
+func (p *Provider) ToGatewayAPI() (i2gw.GatewayResources, field.ErrorList) {
 	return p.converter.convert(p.storage)
 }
 

--- a/pkg/i2gw/providers/kong/converter.go
+++ b/pkg/i2gw/providers/kong/converter.go
@@ -72,7 +72,7 @@ func (c *converter) convert(storage *storage) (i2gw.GatewayResources, field.Erro
 
 	for _, parseFeatureFunc := range c.featureParsers {
 		// Apply the feature parsing function to the gateway resources, one by one.
-		errs = parseFeatureFunc(i2gw.InputResources{Ingresses: ingressList}, &gatewayResources)
+		errs = parseFeatureFunc(ingressList, &gatewayResources)
 		// Append the parsing errors to the error list.
 		globalErrs = append(globalErrs, errs...)
 	}

--- a/pkg/i2gw/providers/kong/converter_test.go
+++ b/pkg/i2gw/providers/kong/converter_test.go
@@ -504,8 +504,7 @@ func Test_ToGateway(t *testing.T) {
 			kongProvider.storage = newResourceStorage()
 			kongProvider.storage.Ingresses = tc.ingresses
 
-			// TODO(#113) we pass an empty i2gw.InputResources temporarily until we change ToGatewayAPI function on the interface
-			gatewayResources, errs := provider.ToGatewayAPI(i2gw.InputResources{})
+			gatewayResources, errs := provider.ToGatewayAPI()
 
 			if len(gatewayResources.HTTPRoutes) != len(tc.expectedGatewayResources.HTTPRoutes) {
 				t.Errorf("Expected %d HTTPRoutes, got %d: %+v",

--- a/pkg/i2gw/providers/kong/header_matching.go
+++ b/pkg/i2gw/providers/kong/header_matching.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw"
 	"github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw/providers/common"
+	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -36,8 +37,8 @@ import (
 //
 // All the values defined for each annotation name, and separated by comma, MUST be ORed.
 // All the annotation names MUST be ANDed, with the respective values.
-func headerMatchingFeature(ingressResources i2gw.InputResources, gatewayResources *i2gw.GatewayResources) field.ErrorList {
-	ruleGroups := common.GetRuleGroups(ingressResources.Ingresses)
+func headerMatchingFeature(ingresses []networkingv1.Ingress, gatewayResources *i2gw.GatewayResources) field.ErrorList {
+	ruleGroups := common.GetRuleGroups(ingresses)
 	for _, rg := range ruleGroups {
 		for _, rule := range rg.Rules {
 			headerskeys, headersValues := parseHeadersAnnotations(rule.Ingress.Annotations)

--- a/pkg/i2gw/providers/kong/kong.go
+++ b/pkg/i2gw/providers/kong/kong.go
@@ -47,9 +47,9 @@ func NewProvider(conf *i2gw.ProviderConf) i2gw.Provider {
 	}
 }
 
-// ToGatewayAPI converts the received i2gw.InputResources to i2gw.GatewayResources
+// ToGatewayAPI converts stored Kong API entities to i2gw.GatewayResources
 // including the kong specific features.
-func (p *Provider) ToGatewayAPI(_ i2gw.InputResources) (i2gw.GatewayResources, field.ErrorList) {
+func (p *Provider) ToGatewayAPI() (i2gw.GatewayResources, field.ErrorList) {
 	return p.converter.convert(p.storage)
 }
 

--- a/pkg/i2gw/providers/kong/method_matching.go
+++ b/pkg/i2gw/providers/kong/method_matching.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw"
 	"github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw/providers/common"
+	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -35,8 +36,8 @@ import (
 // konghq.com/methods: "GET,POST"
 //
 // All the values defined and separated by comma, MUST be ORed.
-func methodMatchingFeature(ingressResources i2gw.InputResources, gatewayResources *i2gw.GatewayResources) field.ErrorList {
-	ruleGroups := common.GetRuleGroups(ingressResources.Ingresses)
+func methodMatchingFeature(ingresses []networkingv1.Ingress, gatewayResources *i2gw.GatewayResources) field.ErrorList {
+	ruleGroups := common.GetRuleGroups(ingresses)
 	for _, rg := range ruleGroups {
 		for _, rule := range rg.Rules {
 			key := types.NamespacedName{Namespace: rule.Ingress.Namespace, Name: common.RouteName(rg.Name, rg.Host)}

--- a/pkg/i2gw/providers/kong/method_matching_test.go
+++ b/pkg/i2gw/providers/kong/method_matching_test.go
@@ -34,44 +34,42 @@ func TestMethodMatchingFeature(t *testing.T) {
 
 	testCases := []struct {
 		name                     string
-		inputResources           i2gw.InputResources
+		ingresses                []networkingv1.Ingress
 		expectedHTTPRouteMatches map[string][][]gatewayv1.HTTPRouteMatch
 		expectedErrors           field.ErrorList
 	}{
 		{
 			name: "method matching - 1 method",
-			inputResources: i2gw.InputResources{
-				Ingresses: []networkingv1.Ingress{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "one-method",
-							Namespace: "default",
-							Annotations: map[string]string{
-								"konghq.com/methods": "GET",
-							},
+			ingresses: []networkingv1.Ingress{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "one-method",
+						Namespace: "default",
+						Annotations: map[string]string{
+							"konghq.com/methods": "GET",
 						},
-						Spec: networkingv1.IngressSpec{
-							IngressClassName: ptrTo("ingress-kong"),
-							Rules: []networkingv1.IngressRule{{
-								Host: "test.mydomain.com",
-								IngressRuleValue: networkingv1.IngressRuleValue{
-									HTTP: &networkingv1.HTTPIngressRuleValue{
-										Paths: []networkingv1.HTTPIngressPath{{
-											Path:     "/",
-											PathType: &iPrefix,
-											Backend: networkingv1.IngressBackend{
-												Service: &networkingv1.IngressServiceBackend{
-													Name: "test",
-													Port: networkingv1.ServiceBackendPort{
-														Number: 80,
-													},
+					},
+					Spec: networkingv1.IngressSpec{
+						IngressClassName: ptrTo("ingress-kong"),
+						Rules: []networkingv1.IngressRule{{
+							Host: "test.mydomain.com",
+							IngressRuleValue: networkingv1.IngressRuleValue{
+								HTTP: &networkingv1.HTTPIngressRuleValue{
+									Paths: []networkingv1.HTTPIngressPath{{
+										Path:     "/",
+										PathType: &iPrefix,
+										Backend: networkingv1.IngressBackend{
+											Service: &networkingv1.IngressServiceBackend{
+												Name: "test",
+												Port: networkingv1.ServiceBackendPort{
+													Number: 80,
 												},
 											},
-										}},
-									},
+										},
+									}},
 								},
-							}},
-						},
+							},
+						}},
 					},
 				},
 			},
@@ -88,38 +86,36 @@ func TestMethodMatchingFeature(t *testing.T) {
 		},
 		{
 			name: "method matching - many methods",
-			inputResources: i2gw.InputResources{
-				Ingresses: []networkingv1.Ingress{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "many-methods",
-							Namespace: "default",
-							Annotations: map[string]string{
-								"konghq.com/methods": "GET,POST,DELETE",
-							},
+			ingresses: []networkingv1.Ingress{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "many-methods",
+						Namespace: "default",
+						Annotations: map[string]string{
+							"konghq.com/methods": "GET,POST,DELETE",
 						},
-						Spec: networkingv1.IngressSpec{
-							IngressClassName: ptrTo("ingress-kong"),
-							Rules: []networkingv1.IngressRule{{
-								Host: "test.mydomain.com",
-								IngressRuleValue: networkingv1.IngressRuleValue{
-									HTTP: &networkingv1.HTTPIngressRuleValue{
-										Paths: []networkingv1.HTTPIngressPath{{
-											Path:     "/",
-											PathType: &iPrefix,
-											Backend: networkingv1.IngressBackend{
-												Service: &networkingv1.IngressServiceBackend{
-													Name: "test",
-													Port: networkingv1.ServiceBackendPort{
-														Number: 80,
-													},
+					},
+					Spec: networkingv1.IngressSpec{
+						IngressClassName: ptrTo("ingress-kong"),
+						Rules: []networkingv1.IngressRule{{
+							Host: "test.mydomain.com",
+							IngressRuleValue: networkingv1.IngressRuleValue{
+								HTTP: &networkingv1.HTTPIngressRuleValue{
+									Paths: []networkingv1.HTTPIngressPath{{
+										Path:     "/",
+										PathType: &iPrefix,
+										Backend: networkingv1.IngressBackend{
+											Service: &networkingv1.IngressServiceBackend{
+												Name: "test",
+												Port: networkingv1.ServiceBackendPort{
+													Number: 80,
 												},
 											},
-										}},
-									},
+										},
+									}},
 								},
-							}},
-						},
+							},
+						}},
 					},
 				},
 			},
@@ -142,38 +138,36 @@ func TestMethodMatchingFeature(t *testing.T) {
 		},
 		{
 			name: "method matching - wrong method",
-			inputResources: i2gw.InputResources{
-				Ingresses: []networkingv1.Ingress{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "wrong-method",
-							Namespace: "default",
-							Annotations: map[string]string{
-								"konghq.com/methods": "WRONG",
-							},
+			ingresses: []networkingv1.Ingress{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "wrong-method",
+						Namespace: "default",
+						Annotations: map[string]string{
+							"konghq.com/methods": "WRONG",
 						},
-						Spec: networkingv1.IngressSpec{
-							IngressClassName: ptrTo("ingress-kong"),
-							Rules: []networkingv1.IngressRule{{
-								Host: "test.mydomain.com",
-								IngressRuleValue: networkingv1.IngressRuleValue{
-									HTTP: &networkingv1.HTTPIngressRuleValue{
-										Paths: []networkingv1.HTTPIngressPath{{
-											Path:     "/",
-											PathType: &iPrefix,
-											Backend: networkingv1.IngressBackend{
-												Service: &networkingv1.IngressServiceBackend{
-													Name: "test",
-													Port: networkingv1.ServiceBackendPort{
-														Number: 80,
-													},
+					},
+					Spec: networkingv1.IngressSpec{
+						IngressClassName: ptrTo("ingress-kong"),
+						Rules: []networkingv1.IngressRule{{
+							Host: "test.mydomain.com",
+							IngressRuleValue: networkingv1.IngressRuleValue{
+								HTTP: &networkingv1.HTTPIngressRuleValue{
+									Paths: []networkingv1.HTTPIngressPath{{
+										Path:     "/",
+										PathType: &iPrefix,
+										Backend: networkingv1.IngressBackend{
+											Service: &networkingv1.IngressServiceBackend{
+												Name: "test",
+												Port: networkingv1.ServiceBackendPort{
+													Number: 80,
 												},
 											},
-										}},
-									},
+										},
+									}},
 								},
-							}},
-						},
+							},
+						}},
 					},
 				},
 			},
@@ -189,14 +183,14 @@ func TestMethodMatchingFeature(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			gatewayResources, errs := common.ToGateway(tc.inputResources.Ingresses, i2gw.ProviderImplementationSpecificOptions{
+			gatewayResources, errs := common.ToGateway(tc.ingresses, i2gw.ProviderImplementationSpecificOptions{
 				ToImplementationSpecificHTTPPathTypeMatch: implementationSpecificHTTPPathTypeMatch,
 			})
 			if len(errs) != 0 {
 				t.Errorf("Expected no errors, got %d: %+v", len(errs), errs)
 			}
 
-			errs = methodMatchingFeature(tc.inputResources, &gatewayResources)
+			errs = methodMatchingFeature(tc.ingresses, &gatewayResources)
 			if len(errs) != len(tc.expectedErrors) {
 				t.Errorf("Expected %d errors, got %d: %+v", len(tc.expectedErrors), len(errs), errs)
 			} else {

--- a/pkg/i2gw/providers/kong/plugins.go
+++ b/pkg/i2gw/providers/kong/plugins.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw"
 	"github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw/providers/common"
+	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -32,8 +33,8 @@ import (
 // a comma-separated list.
 //
 // Example: konghq.com/plugins: "plugin1,plugin2"
-func pluginsFeature(ingressResources i2gw.InputResources, gatewayResources *i2gw.GatewayResources) field.ErrorList {
-	ruleGroups := common.GetRuleGroups(ingressResources.Ingresses)
+func pluginsFeature(ingresses []networkingv1.Ingress, gatewayResources *i2gw.GatewayResources) field.ErrorList {
+	ruleGroups := common.GetRuleGroups(ingresses)
 	for _, rg := range ruleGroups {
 		for _, rule := range rg.Rules {
 			key := types.NamespacedName{Namespace: rule.Ingress.Namespace, Name: common.RouteName(rg.Name, rg.Host)}


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/ingress2gateway/blob/main/CONTRIBUTING.md). -->

<!-- The release notes and the kind will be used to generate the Changelog for the release. To make sure your contribution is recognized, please label this pull request according to what type of issue you are addressing and add the release notes when necessary (see ../CONTRIBUTING.md) -->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

- [x] Deprecate i2gw.InputResources
- [x] Remove input resources from [ToGatewayAPI](https://github.com/kubernetes-sigs/ingress2gateway/blob/654e76fa2ec341b9eaf9f7ba42f12e3305c7b993/pkg/i2gw/provider.go#L73C2-L73C14) function.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #113 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Deprecate `i2gw.InputResources` and remove input resources from `ToGatewayAPI` function
```
