### PR TITLE
feat: bump ReferenceGrant to v1beta1

### DIFF
--- a/pkg/i2gw/ingress2gateway.go
+++ b/pkg/i2gw/ingress2gateway.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 func ToGatewayAPIResources(ctx context.Context, namespace string, inputFile string, providers []string) ([]GatewayResources, error) {
@@ -150,7 +151,7 @@ func MergeGatewayResources(gatewayResources ...GatewayResources) (GatewayResourc
 		TLSRoutes:       make(map[types.NamespacedName]gatewayv1alpha2.TLSRoute),
 		TCPRoutes:       make(map[types.NamespacedName]gatewayv1alpha2.TCPRoute),
 		UDPRoutes:       make(map[types.NamespacedName]gatewayv1alpha2.UDPRoute),
-		ReferenceGrants: make(map[types.NamespacedName]gatewayv1alpha2.ReferenceGrant),
+		ReferenceGrants: make(map[types.NamespacedName]gatewayv1beta1.ReferenceGrant),
 	}
 	var errs field.ErrorList
 	mergedGatewayResources.Gateways, errs = mergeGateways(gatewayResources)

--- a/pkg/i2gw/provider.go
+++ b/pkg/i2gw/provider.go
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 // ProviderConstructorByName is a map of ProviderConstructor functions by a
@@ -100,7 +101,7 @@ type GatewayResources struct {
 	TCPRoutes  map[types.NamespacedName]gatewayv1alpha2.TCPRoute
 	UDPRoutes  map[types.NamespacedName]gatewayv1alpha2.UDPRoute
 
-	ReferenceGrants map[types.NamespacedName]gatewayv1alpha2.ReferenceGrant
+	ReferenceGrants map[types.NamespacedName]gatewayv1beta1.ReferenceGrant
 }
 
 // FeatureParser is a function that reads the InputResources, and applies

--- a/pkg/i2gw/providers/common/converter.go
+++ b/pkg/i2gw/providers/common/converter.go
@@ -93,7 +93,7 @@ var (
 
 	ReferenceGrantGVK = schema.GroupVersionKind{
 		Group:   "gateway.networking.k8s.io",
-		Version: "v1alpha2",
+		Version: "v1beta1",
 		Kind:    "ReferenceGrant",
 	}
 )

--- a/pkg/i2gw/providers/istio/converter_test.go
+++ b/pkg/i2gw/providers/istio/converter_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 func Test_converter_convertGateway(t *testing.T) {
@@ -1565,7 +1566,7 @@ func Test_converter_generateReferenceGrants(t *testing.T) {
 	tests := []struct {
 		name string
 		args args
-		want *gatewayv1alpha2.ReferenceGrant
+		want *gatewayv1beta1.ReferenceGrant
 	}{
 		{
 			name: "generate reference grant for HTTPRoute,TLSRoute,TCPRoute",
@@ -1581,7 +1582,7 @@ func Test_converter_generateReferenceGrants(t *testing.T) {
 					forTCPRoute:   true,
 				},
 			},
-			want: &gatewayv1alpha2.ReferenceGrant{
+			want: &gatewayv1beta1.ReferenceGrant{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: common.ReferenceGrantGVK.GroupVersion().String(),
 					Kind:       common.ReferenceGrantGVK.Kind,
@@ -1590,8 +1591,8 @@ func Test_converter_generateReferenceGrants(t *testing.T) {
 					Namespace: "test",
 					Name:      "generated-reference-grant-from-ns1-to-test",
 				},
-				Spec: gatewayv1alpha2.ReferenceGrantSpec{
-					From: []gatewayv1alpha2.ReferenceGrantFrom{
+				Spec: gatewayv1beta1.ReferenceGrantSpec{
+					From: []gatewayv1beta1.ReferenceGrantFrom{
 						{
 							Group:     gatewayv1.Group(common.HTTPRouteGVK.Group),
 							Kind:      gatewayv1.Kind(common.HTTPRouteGVK.Kind),
@@ -1608,7 +1609,7 @@ func Test_converter_generateReferenceGrants(t *testing.T) {
 							Namespace: gatewayv1.Namespace("ns1"),
 						},
 					},
-					To: []gatewayv1alpha2.ReferenceGrantTo{
+					To: []gatewayv1beta1.ReferenceGrantTo{
 						{
 							Group: gatewayv1.Group(common.GatewayGVK.Group),
 							Kind:  gatewayv1.Kind(common.GatewayGVK.Kind),
@@ -1825,7 +1826,7 @@ func Test_converter_generateReferences(t *testing.T) {
 		fields               fields
 		args                 args
 		wantParentReferences []gatewayv1.ParentReference
-		wantReferenceGrants  []*gatewayv1alpha2.ReferenceGrant
+		wantReferenceGrants  []*gatewayv1beta1.ReferenceGrant
 	}{
 		{
 			name: "nothing is generated if Gateway is not listed in the VirtualService",
@@ -1882,12 +1883,12 @@ func Test_converter_generateReferences(t *testing.T) {
 					Name:      "gateway",
 				},
 			},
-			wantReferenceGrants: []*gatewayv1alpha2.ReferenceGrant{
+			wantReferenceGrants: []*gatewayv1beta1.ReferenceGrant{
 				{
-					TypeMeta:   metav1.TypeMeta{Kind: "ReferenceGrant", APIVersion: "gateway.networking.k8s.io/v1alpha2"},
+					TypeMeta:   metav1.TypeMeta{Kind: "ReferenceGrant", APIVersion: "gateway.networking.k8s.io/v1beta1"},
 					ObjectMeta: metav1.ObjectMeta{Name: "generated-reference-grant-from-test-to-prod", Namespace: "prod"},
-					Spec: gatewayv1alpha2.ReferenceGrantSpec{
-						To: []gatewayv1alpha2.ReferenceGrantTo{
+					Spec: gatewayv1beta1.ReferenceGrantSpec{
+						To: []gatewayv1beta1.ReferenceGrantTo{
 							{
 								Group: "gateway.networking.k8s.io", Kind: "Gateway", Name: common.PtrTo[gatewayv1.ObjectName]("gateway"),
 							},
@@ -1926,7 +1927,7 @@ func Test_converter_generateReferences(t *testing.T) {
 					Name:  "gateway",
 				},
 			},
-			wantReferenceGrants: []*gatewayv1alpha2.ReferenceGrant{},
+			wantReferenceGrants: []*gatewayv1beta1.ReferenceGrant{},
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/i2gw/providers/istio/e2e_file_converter_test.go
+++ b/pkg/i2gw/providers/istio/e2e_file_converter_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 const fixturesDir = "./fixtures"
@@ -108,7 +109,7 @@ func readGatewayResourcesFromFile(t *testing.T, filename string) (*i2gw.GatewayR
 		HTTPRoutes:      make(map[types.NamespacedName]gatewayv1.HTTPRoute),
 		TLSRoutes:       make(map[types.NamespacedName]gatewayv1alpha2.TLSRoute),
 		TCPRoutes:       make(map[types.NamespacedName]gatewayv1alpha2.TCPRoute),
-		ReferenceGrants: make(map[types.NamespacedName]gatewayv1alpha2.ReferenceGrant),
+		ReferenceGrants: make(map[types.NamespacedName]gatewayv1beta1.ReferenceGrant),
 	}
 
 	for _, obj := range unstructuredObjects {
@@ -153,7 +154,7 @@ func readGatewayResourcesFromFile(t *testing.T, filename string) (*i2gw.GatewayR
 				Name:      tcpRoute.Name,
 			}] = tcpRoute
 		case "ReferenceGrant":
-			var referenceGrant gatewayv1alpha2.ReferenceGrant
+			var referenceGrant gatewayv1beta1.ReferenceGrant
 			if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), &referenceGrant); err != nil {
 				return nil, fmt.Errorf("failed to parse k8s gateway ReferenceGrant object: %w", err)
 			}

--- a/pkg/i2gw/providers/istio/fixtures/output/5-referencegrants.yaml
+++ b/pkg/i2gw/providers/istio/fixtures/output/5-referencegrants.yaml
@@ -46,7 +46,7 @@ spec:
       name: test
       weight: 1
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: ReferenceGrant
 metadata:
   name: generated-reference-grant-from-custom-ns-to-prod


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/ingress2gateway/blob/main/CONTRIBUTING.md). -->

<!-- The release notes and the kind will be used to generate the Changelog for the release. To make sure your contribution is recognized, please label this pull request according to what type of issue you are addressing and add the release notes when necessary (see ../CONTRIBUTING.md) -->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
`ReferenceGrant` has been promoted to `v1beta1` but we are still using the `alpha` version. We should bump the API.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #140 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Bump `ReferenceGrant` to `v1beta1`
```
