### PR TITLE
fix: execution fails when istio CRD is not installed in the cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,14 +61,14 @@ This above command will:
 
 ### `print` command
 
-| Flag           | Default Value           | Required | Description                                                  |
-| -------------- | ----------------------- | -------- | ------------------------------------------------------------ |
-| namespace      |                         | No       | If present, the namespace scope for the invocation           |
-| all-namespaces | False                   | No       | If present, list the requested object(s) across all namespaces. Namespace in the current context is ignored even if specified with --namespace |
-| output         | yaml                    | No       | The output format, either yaml or json                       |
-| input_file     |                         | No       | Path to the manifest file. When set, the tool will read ingresses from the file instead of reading from the cluster. Supported files are yaml and json |
-| providers      | all supported providers | No       | Comma-separated list of providers. If present, the tool will try to convert only resources related to the specified providers. Otherwise it will default to all the supported providers |
-| kubeconfig     |                         | No       | The kubeconfig file to use when talking to the cluster. If the flag is not set, a set of standard locations can be searched for an existing kubeconfig file. |
+| Flag           | Default Value | Required | Description                                                  |
+| -------------- | ------------- | -------- | ------------------------------------------------------------ |
+| namespace      |               | No       | If present, the namespace scope for the invocation           |
+| all-namespaces | False         | No       | If present, list the requested object(s) across all namespaces. Namespace in the current context is ignored even if specified with --namespace |
+| output         | yaml          | No       | The output format, either yaml or json                       |
+| input_file     |               | No       | Path to the manifest file. When set, the tool will read ingresses from the file instead of reading from the cluster. Supported files are yaml and json |
+| providers      |               | Yes      | Comma-separated list of providers. If present, the tool will try to convert only resources related to the specified providers. Otherwise it will default to all the supported providers |
+| kubeconfig     |               | No       | The kubeconfig file to use when talking to the cluster. If the flag is not set, a set of standard locations can be searched for an existing kubeconfig file. |
 
 ## Conversion of Ingress resources to Gateway API
 

--- a/cmd/print.go
+++ b/cmd/print.go
@@ -67,7 +67,7 @@ type PrintRunner struct {
 func (pr *PrintRunner) PrintGatewaysAndHTTPRoutes(cmd *cobra.Command, _ []string) error {
 	err := pr.initializeResourcePrinter()
 	if err != nil {
-		return fmt.Errorf("failed to initialize resrouce printer: %w", err)
+		return fmt.Errorf("failed to initialize resource printer: %w", err)
 	}
 	err = pr.initializeNamespaceFilter()
 	if err != nil {
@@ -245,10 +245,11 @@ func newPrintCommand() *cobra.Command {
 		`If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even
 if specified with --namespace.`)
 
-	cmd.Flags().StringSliceVar(&pr.providers, "providers", i2gw.GetSupportedProviders(),
+	cmd.Flags().StringSliceVar(&pr.providers, "providers", nil,
 		fmt.Sprintf("If present, the tool will try to convert only resources related to the specified providers, supported values are %v", i2gw.GetSupportedProviders()))
 
 	cmd.MarkFlagsMutuallyExclusive("namespace", "all-namespaces")
+	cmd.MarkFlagRequired("providers")
 	return cmd
 }
 

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/stretchr/testify v1.9.0
 	istio.io/api v1.20.0
 	k8s.io/api v0.28.4
+	k8s.io/apiextensions-apiserver v0.28.4
 	k8s.io/apimachinery v0.28.4
 	k8s.io/cli-runtime v0.28.4
 	k8s.io/client-go v0.28.4

--- a/go.sum
+++ b/go.sum
@@ -231,8 +231,8 @@ istio.io/client-go v1.19.0-alpha.1.0.20231130185426-9f1859c8ff42 h1:YOTiFclrIEag
 istio.io/client-go v1.19.0-alpha.1.0.20231130185426-9f1859c8ff42/go.mod h1:yifta8BCYPNw5wFf42Jqt55cnGocIW0DxGlltwQUAaM=
 k8s.io/api v0.28.4 h1:8ZBrLjwosLl/NYgv1P7EQLqoO8MGQApnbgH8tu3BMzY=
 k8s.io/api v0.28.4/go.mod h1:axWTGrY88s/5YE+JSt4uUi6NMM+gur1en2REMR7IRj0=
-k8s.io/apiextensions-apiserver v0.28.3 h1:Od7DEnhXHnHPZG+W9I97/fSQkVpVPQx2diy+2EtmY08=
-k8s.io/apiextensions-apiserver v0.28.3/go.mod h1:NE1XJZ4On0hS11aWWJUTNkmVB03j9LM7gJSisbRt8Lc=
+k8s.io/apiextensions-apiserver v0.28.4 h1:AZpKY/7wQ8n+ZYDtNHbAJBb+N4AXXJvyZx6ww6yAJvU=
+k8s.io/apiextensions-apiserver v0.28.4/go.mod h1:pgQIZ1U8eJSMQcENew/0ShUTlePcSGFq6dxSxf2mwPM=
 k8s.io/apimachinery v0.28.4 h1:zOSJe1mc+GxuMnFzD4Z/U1wst50X28ZNsn5bhgIIao8=
 k8s.io/apimachinery v0.28.4/go.mod h1:wI37ncBvfAoswfq626yPTe6Bz1c22L7uaJ8dho83mgg=
 k8s.io/cli-runtime v0.28.4 h1:IW3aqSNFXiGDllJF4KVYM90YX4cXPGxuCxCVqCD8X+Q=

--- a/pkg/i2gw/providers/istio/types.go
+++ b/pkg/i2gw/providers/istio/types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package istio
 
 const (
+	CRDName            = "gateways.networking.istio.io"
 	APIVersion         = "networking.istio.io/v1beta1"
 	GatewayKind        = "Gateway"
 	VirtualServiceKind = "VirtualService"


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/ingress2gateway/blob/main/CONTRIBUTING.md). -->

<!-- The release notes and the kind will be used to generate the Changelog for the release. To make sure your contribution is recognized, please label this pull request according to what type of issue you are addressing and add the release notes when necessary (see ../CONTRIBUTING.md) -->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
1. Enforce to specify --providers, and not default to all providers
2. Fail soft with a warning if the provider specified is not the provider whose CRDs are not installed

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #138 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note

```
