### PR TITLE
Add instructions for installing binary via Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ This will put `ingress2gateway` binary in `$(go env GOPATH)/bin`
 
 Alternatively, you can download the binary at the [releases page](https://github.com/kubernetes-sigs/ingress2gateway/releases)
 
+### On macOS and linux via Homebrew:
+Make sure Homebrew is installed on your system.
+```shell
+brew install ingress2gateway
+```
+
 ### Build from Source
 
 1. Ensure that your system meets the following requirements:


### PR DESCRIPTION
Added instructions for installing the binary via Homebrew on macOS and Linux to make it easier for users to obtain the `ingress2gateway` binary. This provides an alternative method to building from the source.

<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/ingress2gateway/blob/main/CONTRIBUTING.md). -->

<!-- The release notes and the kind will be used to generate the Changelog for the release. To make sure your contribution is recognized, please label this pull request according to what type of issue you are addressing and add the release notes when necessary (see ../CONTRIBUTING.md) -->

**What type of PR is this?**
/kind documentation
<!--
Add one of the following kinds:
kind documentation

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
Added instructions for installing the binary via Homebrew on macOS and Linux tomake it easier for users to obtain the  ingress2gateway binary. This provides an alternative method to building from the source.
https://github.com/Homebrew/homebrew-core/pull/166817

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
