### PR TITLE
move bowei and shaneutt to emeritus_approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,13 +1,15 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - bowei
-  - robscott
-  - shaneutt
-  - youngnick
   - LiorLieberman
+  - mlavacca  
+  - robscott
+  - youngnick
 
 reviewers:
   - levikobi
   - Xunzhuo
-  - mlavacca
+
+emeritus_approvers:
+  - bowei
+  - shaneutt


### PR DESCRIPTION

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
