### PR TITLE
Improve error handling across kong & ingress-nginx

### DIFF
--- a/pkg/i2gw/providers/common/converter.go
+++ b/pkg/i2gw/providers/common/converter.go
@@ -362,6 +362,11 @@ func toHTTPRouteMatch(routePath networkingv1.HTTPIngressPath, path *field.Path, 
 	pmExact := gatewayv1.PathMatchExact
 
 	match := &gatewayv1.HTTPRouteMatch{Path: &gatewayv1.HTTPPathMatch{Value: &routePath.Path}}
+
+	if routePath.PathType == nil {
+		return nil, field.Invalid(path.Child("pathType"), routePath.PathType, "pathType is required")
+	}
+
 	switch *routePath.PathType {
 	case networkingv1.PathTypePrefix:
 		match.Path.Type = &pmPrefix

--- a/pkg/i2gw/providers/ingressnginx/canary.go
+++ b/pkg/i2gw/providers/ingressnginx/canary.go
@@ -47,7 +47,9 @@ func canaryFeature(ingressResources i2gw.InputResources, gatewayResources *i2gw.
 			key := types.NamespacedName{Namespace: path.ingress.Namespace, Name: common.RouteName(rg.Name, rg.Host)}
 			httpRoute, ok := gatewayResources.HTTPRoutes[key]
 			if !ok {
-				panic("HTTPRoute not exists - this should never happen")
+				// If there wasn't an HTTPRoute for this Ingress, we can skip it as something is wrong.
+				// All the available errors will be returned at the end.
+				continue
 			}
 
 			patchHTTPRouteWithBackendRefs(&httpRoute, backendRefs)

--- a/pkg/i2gw/providers/kong/header_matching.go
+++ b/pkg/i2gw/providers/kong/header_matching.go
@@ -44,7 +44,7 @@ func headerMatchingFeature(ingressResources i2gw.InputResources, gatewayResource
 			key := types.NamespacedName{Namespace: rule.Ingress.Namespace, Name: common.RouteName(rg.Name, rg.Host)}
 			httpRoute, ok := gatewayResources.HTTPRoutes[key]
 			if !ok {
-				panic("HTTPRoute does not exist - this should never happen")
+				return field.ErrorList{field.InternalError(nil, fmt.Errorf("HTTPRoute does not exist - this should never happen"))}
 			}
 
 			patchHTTPRouteHeaderMatching(&httpRoute, headerskeys, headersValues)

--- a/pkg/i2gw/providers/kong/method_matching.go
+++ b/pkg/i2gw/providers/kong/method_matching.go
@@ -42,7 +42,7 @@ func methodMatchingFeature(ingressResources i2gw.InputResources, gatewayResource
 			key := types.NamespacedName{Namespace: rule.Ingress.Namespace, Name: common.RouteName(rg.Name, rg.Host)}
 			httpRoute, ok := gatewayResources.HTTPRoutes[key]
 			if !ok {
-				panic("HTTPRoute does not exist - this should never happen")
+				return field.ErrorList{field.InternalError(nil, fmt.Errorf("HTTPRoute does not exist - this should never happen"))}
 			}
 			methods, errs := parseMethodsAnnotation(rule.Ingress.ObjectMeta.Namespace, rule.Ingress.ObjectMeta.Name, rule.Ingress.Annotations)
 			if len(errs) != 0 {

--- a/pkg/i2gw/providers/kong/plugins.go
+++ b/pkg/i2gw/providers/kong/plugins.go
@@ -17,6 +17,7 @@ limitations under the License.
 package kong
 
 import (
+	"errors"
 	"strings"
 
 	"github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw"
@@ -39,7 +40,7 @@ func pluginsFeature(ingressResources i2gw.InputResources, gatewayResources *i2gw
 			key := types.NamespacedName{Namespace: rule.Ingress.Namespace, Name: common.RouteName(rg.Name, rg.Host)}
 			httpRoute, ok := gatewayResources.HTTPRoutes[key]
 			if !ok {
-				panic("HTTPRoute does not exist - this should never happen")
+				return field.ErrorList{field.InternalError(nil, errors.New("HTTPRoute does not exist - this should never happen"))}
 			}
 			filters := parsePluginsAnnotation(rule.Ingress.Annotations)
 			patchHTTPRoutePlugins(&httpRoute, filters)


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/ingress2gateway/blob/main/CONTRIBUTING.md). -->

<!-- The release notes and the kind will be used to generate the Changelog for the release. To make sure your contribution is recognized, please label this pull request according to what type of issue you are addressing and add the release notes when necessary (see ../CONTRIBUTING.md) -->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

**What this PR does / why we need it**:
Improves error handling across Kong and ingress-nginx providers by removing panic calls and stopping conversions if an error occurs.
Also, prevents the tool from crashing in case no `pathType` is specified.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #151 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
* Improves error handling for Kong and Ingress Nginx providers, making them more understandable.
* Prevents the tool from crashing in case no `pathType` is specified
```
