### PR TITLE
fail soft when crds are not installed

### DIFF
--- a/pkg/i2gw/providers/istio/resource_reader.go
+++ b/pkg/i2gw/providers/istio/resource_reader.go
@@ -29,6 +29,8 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type reader struct {
@@ -126,6 +128,10 @@ func (r *reader) readGatewaysFromCluster(ctx context.Context) (map[types.Namespa
 
 	err := r.conf.Client.List(ctx, gatewayList)
 	if err != nil {
+		if client.IgnoreNotFound(err) == nil {
+			klog.Warningf("couldn't find %s CRD, it is likely not installed in the cluster", fmt.Sprintf("%s.%s", APIVersion, GatewayKind))
+			return map[types.NamespacedName]*istiov1beta1.Gateway{}, nil
+		}
 		return nil, fmt.Errorf("failed to list istio gateways: %w", err)
 	}
 
@@ -152,6 +158,10 @@ func (r *reader) readVirtualServicesFromCluster(ctx context.Context) (map[types.
 
 	err := r.conf.Client.List(ctx, virtualServicesList)
 	if err != nil {
+		if client.IgnoreNotFound(err) == nil {
+			klog.Warningf("couldn't find %s CRD, it is likely not installed in the cluster", fmt.Sprintf("%s.%s", APIVersion, VirtualServiceKind))
+			return map[types.NamespacedName]*istiov1beta1.VirtualService{}, nil
+		}
 		return nil, fmt.Errorf("failed to list istio virtual services: %w", err)
 	}
 

--- a/pkg/i2gw/providers/kong/resource_reader.go
+++ b/pkg/i2gw/providers/kong/resource_reader.go
@@ -24,6 +24,8 @@ import (
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kongv1beta1 "github.com/kong/kubernetes-ingress-controller/v2/pkg/apis/configuration/v1beta1"
 	"github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw"
@@ -92,7 +94,11 @@ func (r *resourceReader) readTCPIngressesFromCluster(ctx context.Context) ([]kon
 
 	err := r.conf.Client.List(ctx, tcpIngressList)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list Kong TCPIngresses: %w", err)
+		if client.IgnoreNotFound(err) == nil {
+			klog.Warningf("couldn't find %s CRD, it is likely not installed in the cluster", tcpIngressGVK.GroupKind().String())
+			return []kongv1beta1.TCPIngress{}, nil
+		}
+		return nil, fmt.Errorf("failed to list %s: %w", tcpIngressGVK.GroupKind().String(), err)
 	}
 
 	tcpIngresses := []kongv1beta1.TCPIngress{}


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/ingress2gateway/blob/main/CONTRIBUTING.md). -->

<!-- The release notes and the kind will be used to generate the Changelog for the release. To make sure your contribution is recognized, please label this pull request according to what type of issue you are addressing and add the release notes when necessary (see ../CONTRIBUTING.md) -->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Execution should work regardless of whether CRDs are installed or not
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #138 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Fix errors when CRDs are not installed in the cluster
```
