### PR TITLE
Add new command to list flags for documentation

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+var generateReadmeFlags = map[string]struct{}{
+	"print": {},
+}
+
+func newListFlagsCommand(rootCmd *cobra.Command) *cobra.Command {
+	return &cobra.Command{
+		Use:   "list-flags",
+		Short: "Lists all flags for documentation",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			table := tablewriter.NewWriter(os.Stdout)
+			printCommandFlags(rootCmd, table)
+			return nil
+		},
+	}
+}
+
+func printCommandFlags(cmd *cobra.Command, table *tablewriter.Table) {
+	if _, ok := generateReadmeFlags[cmd.Use]; ok {
+		fmt.Printf("\n### `%s` command\n\n", cmd.Use)
+
+		table.SetHeader([]string{"Flag", "Default Value", "Required", "Description"})
+
+		cmd.Flags().VisitAll(func(flag *pflag.Flag) {
+			table.Append([]string{
+				flag.Name,
+				flag.DefValue,
+				fmt.Sprintf("%v", flag.NoOptDefVal == ""),
+				flag.Usage,
+			})
+		})
+
+		table.Render()
+
+		table.ClearRows()
+	}
+
+	for _, subCmd := range cmd.Commands() {
+		printCommandFlags(subCmd, table)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -48,6 +48,7 @@ func getKubeconfig() {
 func Execute() {
 	rootCmd := newRootCmd()
 	rootCmd.AddCommand(newPrintCommand())
+	rootCmd.AddCommand(newListFlagsCommand(rootCmd))
 	err := rootCmd.Execute()
 	if err != nil {
 		os.Exit(1)


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/ingress2gateway/blob/main/CONTRIBUTING.md). -->

<!-- The release notes and the kind will be used to generate the Changelog for the release. To make sure your contribution is recognized, please label this pull request according to what type of issue you are addressing and add the release notes when necessary (see ../CONTRIBUTING.md) -->

**What type of PR is this?**
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:
Adds list-flags command to print flag details directly.
usage:
```
./ingress2gateway list-flags
```
Output:
```
 
### `print` command

+-----------------------------+---------------+----------+--------------------------------+
|            FLAG             | DEFAULT VALUE | REQUIRED |          DESCRIPTION           |
+-----------------------------+---------------+----------+--------------------------------+
| all-namespaces              | false         | false    | If present, list the           |
|                             |               |          | requested object(s) across     |
|                             |               |          | all namespaces. Namespace in   |
|                             |               |          | current context is ignored     |
|                             |               |          | even if specified with         |
|                             |               |          | --namespace.                   |
| input-file                  |               | true     | Path to the manifest file.     |
|                             |               |          | When set, the tool will        |
|                             |               |          | read ingresses from the file   |
|                             |               |          | instead of reading from the    |
|                             |               |          | cluster. Supported files are   |
|                             |               |          | yaml and json.                 |
| namespace                   |               | true     | If present, the namespace      |
|                             |               |          | scope for this CLI request.    |
| openapi3-backend            |               | true     | Provider-specific: openapi3.   |
|                             |               |          | The name of the backend        |
|                             |               |          | service to use in the          |
|                             |               |          | HTTPRoutes.                    |
| openapi3-gateway-class-name |               | true     | Provider-specific: openapi3.   |
|                             |               |          | The name of the gateway class  |
|                             |               |          | to use in the Gateways.        |
| openapi3-gateway-tls-secret |               | true     | Provider-specific: openapi3.   |
|                             |               |          | The name of the secret for the |
|                             |               |          | TLS certificate references in  |
|                             |               |          | the Gateways.                  |
| output                      | yaml          | true     | Output format. One of: (json,  |
|                             |               |          | yaml).                         |
| providers                   | []            | true     | If present, the tool will      |
|                             |               |          | try to convert only resources  |
|                             |               |          | related to the specified       |
|                             |               |          | providers, supported values    |
|                             |               |          | are [apisix gce ingress-nginx  |
|                             |               |          | istio kong openapi3].          |
+-----------------------------+---------------+----------+--------------------------------+

```
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
As part of issue #162, we're adding a new command to list flags for documentation. This will aid in automating the process of generating a list of available flags for creating a README.md file.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
None
```
