### PR TITLE
ingress-nginx: apply canary to httproute only when enabled

### DIFF
--- a/pkg/i2gw/providers/ingressnginx/canary.go
+++ b/pkg/i2gw/providers/ingressnginx/canary.go
@@ -73,12 +73,14 @@ func getPathsByMatchGroups(rg common.IngressRuleGroup) (map[pathMatchKey][]ingre
 			return nil, errs
 		}
 
-		extraFeatures := extra{canary: &annotations}
+		if annotations.enable {
+			extraFeatures := extra{canary: &annotations}
 
-		for _, path := range ir.IngressRule.HTTP.Paths {
-			ip := ingressPath{ingress: ingress, ruleType: "http", path: path, extra: &extraFeatures}
-			pmKey := getPathMatchKey(ip)
-			ingressPathsByMatchKey[pmKey] = append(ingressPathsByMatchKey[pmKey], ip)
+			for _, path := range ir.IngressRule.HTTP.Paths {
+				ip := ingressPath{ingress: ingress, ruleType: "http", path: path, extra: &extraFeatures}
+				pmKey := getPathMatchKey(ip)
+				ingressPathsByMatchKey[pmKey] = append(ingressPathsByMatchKey[pmKey], ip)
+			}
 		}
 	}
 


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/ingress2gateway/blob/main/CONTRIBUTING.md). -->

<!-- The release notes and the kind will be used to generate the Changelog for the release. To make sure your contribution is recognized, please label this pull request according to what type of issue you are addressing and add the release notes when necessary (see ../CONTRIBUTING.md) -->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
This is a fix for #174, we should not try to parse canary if its not enabled with the corresponding ingress annotations.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #174 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
ingress-nginx: fix backendRefs duplication due to wrong canary annotations logic
```

/cc @levikobi 