### PR TITLE
Created new flag `--notifications-output-file` to specify where to output notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ The above command will:
 | output         | yaml                    | No       | The output format, either yaml or json.                       |
 | providers      | all supported providers | Yes       | Comma-separated list of providers. |
 | kubeconfig     |                         | No       | The kubeconfig file to use when talking to the cluster. If the flag is not set, a set of standard locations can be searched for an existing kubeconfig file. |
+| notifications-output-file     |                         | No       | The path to the file where notifications will be written to. If the flag is not present, notifications will be printed to stdout. |
 
 ## Conversion of Ingress resources to Gateway API
 


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/ingress2gateway/blob/main/CONTRIBUTING.md). -->

<!-- The release notes and the kind will be used to generate the Changelog for the release. To make sure your contribution is recognized, please label this pull request according to what type of issue you are addressing and add the release notes when necessary (see ../CONTRIBUTING.md) -->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

**What this PR does / why we need it**:
This PR adds a new flag called `--notifications-output-file` to specify where to output notifications. If the flag is not present, then notifications are send to stdout.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
This pull request addresses part of the issue described in #131 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Added flag `--notifications-output-file`.
```
/cc @mlavacca @LiorLieberman 