### PR TITLE
nginx: apply canary only for enabled rule groups

### DIFF
--- a/pkg/i2gw/providers/ingressnginx/canary.go
+++ b/pkg/i2gw/providers/ingressnginx/canary.go
@@ -39,24 +39,35 @@ func canaryFeature(ingresses []networkingv1.Ingress, gatewayResources *i2gw.Gate
 			return errs
 		}
 
+		canaryEnabled := false
 		for _, paths := range ingressPathsByMatchKey {
-			path := paths[0]
-
-			backendRefs, calculationErrs := calculateBackendRefWeight(paths)
-			errs = append(errs, calculationErrs...)
-
-			key := types.NamespacedName{Namespace: path.ingress.Namespace, Name: common.RouteName(rg.Name, rg.Host)}
-			httpRoute, ok := gatewayResources.HTTPRoutes[key]
-			if !ok {
-				// If there wasn't an HTTPRoute for this Ingress, we can skip it as something is wrong.
-				// All the available errors will be returned at the end.
-				continue
+			for _, path := range paths {
+				if path.extra.canary.enable {
+					canaryEnabled = true
+				}
 			}
-
-			patchHTTPRouteWithBackendRefs(&httpRoute, backendRefs)
 		}
-		if len(errs) > 0 {
-			return errs
+
+		if canaryEnabled {
+			for _, paths := range ingressPathsByMatchKey {
+				path := paths[0]
+
+				backendRefs, calculationErrs := calculateBackendRefWeight(paths)
+				errs = append(errs, calculationErrs...)
+
+				key := types.NamespacedName{Namespace: path.ingress.Namespace, Name: common.RouteName(rg.Name, rg.Host)}
+				httpRoute, ok := gatewayResources.HTTPRoutes[key]
+				if !ok {
+					// If there wasn't an HTTPRoute for this Ingress, we can skip it as something is wrong.
+					// All the available errors will be returned at the end.
+					continue
+				}
+
+				patchHTTPRouteWithBackendRefs(&httpRoute, backendRefs)
+			}
+			if len(errs) > 0 {
+				return errs
+			}
 		}
 	}
 

--- a/pkg/i2gw/providers/ingressnginx/canary.go
+++ b/pkg/i2gw/providers/ingressnginx/canary.go
@@ -103,19 +103,13 @@ func patchHTTPRouteWithBackendRefs(httpRoute *gatewayv1.HTTPRoute, backendRefs [
 
 		ruleExists = false
 
-		for j, rule := range httpRoute.Spec.Rules {
-			foundBackendRef := false
+		for _, rule := range httpRoute.Spec.Rules {
 			for i := range rule.BackendRefs {
 				if backendRef.Name == rule.BackendRefs[i].Name {
 					rule.BackendRefs[i].Weight = backendRef.Weight
-					foundBackendRef = true
 					ruleExists = true
 					break
 				}
-			}
-
-			if !foundBackendRef {
-				httpRoute.Spec.Rules[j].BackendRefs = append(rule.BackendRefs, backendRef)
 			}
 		}
 

--- a/pkg/i2gw/providers/ingressnginx/canary.go
+++ b/pkg/i2gw/providers/ingressnginx/canary.go
@@ -39,6 +39,9 @@ func canaryFeature(ingresses []networkingv1.Ingress, gatewayResources *i2gw.Gate
 			return errs
 		}
 
+		// We're dividing ingresses based on rule groups.  If any path within a
+		// rule group is associated with an ingress object containing canary annotations,
+		// the entire rule group is affected.
 		canaryEnabled := false
 		for _, paths := range ingressPathsByMatchKey {
 			for _, path := range paths {

--- a/pkg/i2gw/providers/ingressnginx/converter_test.go
+++ b/pkg/i2gw/providers/ingressnginx/converter_test.go
@@ -214,6 +214,204 @@ func Test_ToGateway(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "multiple rules",
+			ingresses: OrderedIngressMap{
+				ingressNames: []types.NamespacedName{{Namespace: "default", Name: "example-ingress"}},
+				ingressObjects: map[types.NamespacedName]*networkingv1.Ingress{
+					{Namespace: "default", Name: "example-ingress"}: {
+						ObjectMeta: metav1.ObjectMeta{Name: "example-ingress", Namespace: "default"},
+						Spec: networkingv1.IngressSpec{
+							IngressClassName: ptrTo("nginx"),
+							TLS: []networkingv1.IngressTLS{{
+								Hosts: []string{
+									"foo.example.com",
+									"bar.example.com",
+								},
+								SecretName: "example-com",
+							}},
+							Rules: []networkingv1.IngressRule{
+								{
+									Host: "foo.example.com",
+									IngressRuleValue: networkingv1.IngressRuleValue{
+										HTTP: &networkingv1.HTTPIngressRuleValue{
+											Paths: []networkingv1.HTTPIngressPath{
+												{
+													Path:     "/",
+													PathType: &iPrefix,
+													Backend: networkingv1.IngressBackend{
+														Service: &networkingv1.IngressServiceBackend{
+															Name: "foo-app",
+															Port: networkingv1.ServiceBackendPort{Number: 80},
+														},
+													},
+												},
+												{
+													Path:     "/orders",
+													PathType: &iPrefix,
+													Backend: networkingv1.IngressBackend{
+														Service: &networkingv1.IngressServiceBackend{
+															Name: "foo-orders-app",
+															Port: networkingv1.ServiceBackendPort{Number: 80},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+								{
+									Host: "bar.example.com",
+									IngressRuleValue: networkingv1.IngressRuleValue{
+										HTTP: &networkingv1.HTTPIngressRuleValue{
+											Paths: []networkingv1.HTTPIngressPath{
+												{
+													Path:     "/",
+													PathType: &iPrefix,
+													Backend: networkingv1.IngressBackend{
+														Service: &networkingv1.IngressServiceBackend{
+															Name: "bar-app",
+															Port: networkingv1.ServiceBackendPort{Number: 80},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedGatewayResources: i2gw.GatewayResources{
+				Gateways: map[types.NamespacedName]gatewayv1.Gateway{
+					{Namespace: "default", Name: "nginx"}: {
+						ObjectMeta: metav1.ObjectMeta{Name: "nginx", Namespace: "default"},
+						Spec: gatewayv1.GatewaySpec{
+							GatewayClassName: "nginx",
+							Listeners: []gatewayv1.Listener{
+								{
+									Name:     "foo-example-com-http",
+									Port:     80,
+									Protocol: gatewayv1.HTTPProtocolType,
+									Hostname: ptrTo(gatewayv1.Hostname("foo.example.com")),
+								},
+								{
+									Name:     "foo-example-com-https",
+									Port:     443,
+									Protocol: gatewayv1.HTTPSProtocolType,
+									Hostname: ptrTo(gatewayv1.Hostname("foo.example.com")),
+									TLS: &gatewayv1.GatewayTLSConfig{
+										CertificateRefs: []gatewayv1.SecretObjectReference{
+											{Name: "example-com"},
+										},
+									},
+								},
+								{
+									Name:     "bar-example-com-http",
+									Port:     80,
+									Protocol: gatewayv1.HTTPProtocolType,
+									Hostname: ptrTo(gatewayv1.Hostname("bar.example.com")),
+								},
+								{
+									Name:     "bar-example-com-https",
+									Port:     443,
+									Protocol: gatewayv1.HTTPSProtocolType,
+									Hostname: ptrTo(gatewayv1.Hostname("bar.example.com")),
+									TLS: &gatewayv1.GatewayTLSConfig{
+										CertificateRefs: []gatewayv1.SecretObjectReference{
+											{Name: "example-com"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				HTTPRoutes: map[types.NamespacedName]gatewayv1.HTTPRoute{
+					{Namespace: "default", Name: "example-ingress-bar-example-com"}: {
+						ObjectMeta: metav1.ObjectMeta{Name: "example-ingress-bar-example-com", Namespace: "default"},
+						Spec: gatewayv1.HTTPRouteSpec{
+							CommonRouteSpec: gatewayv1.CommonRouteSpec{
+								ParentRefs: []gatewayv1.ParentReference{{
+									Name: "nginx",
+								}},
+							},
+							Hostnames: []gatewayv1.Hostname{"bar.example.com"},
+							Rules: []gatewayv1.HTTPRouteRule{{
+								Matches: []gatewayv1.HTTPRouteMatch{{
+									Path: &gatewayv1.HTTPPathMatch{
+										Type:  &gPathPrefix,
+										Value: ptrTo("/"),
+									},
+								}},
+								BackendRefs: []gatewayv1.HTTPBackendRef{
+									{
+										BackendRef: gatewayv1.BackendRef{
+											BackendObjectReference: gatewayv1.BackendObjectReference{
+												Name: "bar-app",
+												Port: ptrTo(gatewayv1.PortNumber(80)),
+											},
+										},
+									},
+								},
+							}},
+						},
+					},
+					{Namespace: "default", Name: "example-ingress-foo-example-com"}: {
+						ObjectMeta: metav1.ObjectMeta{Name: "example-ingress-foo-example-com", Namespace: "default"},
+						Spec: gatewayv1.HTTPRouteSpec{
+							CommonRouteSpec: gatewayv1.CommonRouteSpec{
+								ParentRefs: []gatewayv1.ParentReference{{
+									Name: "nginx",
+								}},
+							},
+							Hostnames: []gatewayv1.Hostname{"foo.example.com"},
+							Rules: []gatewayv1.HTTPRouteRule{
+								{
+									Matches: []gatewayv1.HTTPRouteMatch{{
+										Path: &gatewayv1.HTTPPathMatch{
+											Type:  &gPathPrefix,
+											Value: ptrTo("/"),
+										},
+									}},
+									BackendRefs: []gatewayv1.HTTPBackendRef{
+										{
+											BackendRef: gatewayv1.BackendRef{
+												BackendObjectReference: gatewayv1.BackendObjectReference{
+													Name: "foo-app",
+													Port: ptrTo(gatewayv1.PortNumber(80)),
+												},
+											},
+										},
+									},
+								},
+								{
+									Matches: []gatewayv1.HTTPRouteMatch{{
+										Path: &gatewayv1.HTTPPathMatch{
+											Type:  &gPathPrefix,
+											Value: ptrTo("/orders"),
+										},
+									}},
+									BackendRefs: []gatewayv1.HTTPBackendRef{
+										{
+											BackendRef: gatewayv1.BackendRef{
+												BackendObjectReference: gatewayv1.BackendObjectReference{
+													Name: "foo-orders-app",
+													Port: ptrTo(gatewayv1.PortNumber(80)),
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedErrors: field.ErrorList{},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/i2gw/providers/ingressnginx/converter_test.go
+++ b/pkg/i2gw/providers/ingressnginx/converter_test.go
@@ -215,7 +215,7 @@ func Test_ToGateway(t *testing.T) {
 			},
 		},
 		{
-			name: "multiple rules",
+			name: "multiple rules with TLS",
 			ingresses: OrderedIngressMap{
 				ingressNames: []types.NamespacedName{{Namespace: "default", Name: "example-ingress"}},
 				ingressObjects: map[types.NamespacedName]*networkingv1.Ingress{
@@ -353,6 +353,222 @@ func Test_ToGateway(t *testing.T) {
 												Name: "bar-app",
 												Port: ptrTo(gatewayv1.PortNumber(80)),
 											},
+										},
+									},
+								},
+							}},
+						},
+					},
+					{Namespace: "default", Name: "example-ingress-foo-example-com"}: {
+						ObjectMeta: metav1.ObjectMeta{Name: "example-ingress-foo-example-com", Namespace: "default"},
+						Spec: gatewayv1.HTTPRouteSpec{
+							CommonRouteSpec: gatewayv1.CommonRouteSpec{
+								ParentRefs: []gatewayv1.ParentReference{{
+									Name: "nginx",
+								}},
+							},
+							Hostnames: []gatewayv1.Hostname{"foo.example.com"},
+							Rules: []gatewayv1.HTTPRouteRule{
+								{
+									Matches: []gatewayv1.HTTPRouteMatch{{
+										Path: &gatewayv1.HTTPPathMatch{
+											Type:  &gPathPrefix,
+											Value: ptrTo("/"),
+										},
+									}},
+									BackendRefs: []gatewayv1.HTTPBackendRef{
+										{
+											BackendRef: gatewayv1.BackendRef{
+												BackendObjectReference: gatewayv1.BackendObjectReference{
+													Name: "foo-app",
+													Port: ptrTo(gatewayv1.PortNumber(80)),
+												},
+											},
+										},
+									},
+								},
+								{
+									Matches: []gatewayv1.HTTPRouteMatch{{
+										Path: &gatewayv1.HTTPPathMatch{
+											Type:  &gPathPrefix,
+											Value: ptrTo("/orders"),
+										},
+									}},
+									BackendRefs: []gatewayv1.HTTPBackendRef{
+										{
+											BackendRef: gatewayv1.BackendRef{
+												BackendObjectReference: gatewayv1.BackendObjectReference{
+													Name: "foo-orders-app",
+													Port: ptrTo(gatewayv1.PortNumber(80)),
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedErrors: field.ErrorList{},
+		},
+		{
+			name: "multiple rules with canary",
+			ingresses: OrderedIngressMap{
+				ingressNames: []types.NamespacedName{
+					{Namespace: "default", Name: "example-ingress"},
+					{Namespace: "default", Name: "example-ingress-canary"},
+				},
+				ingressObjects: map[types.NamespacedName]*networkingv1.Ingress{
+					{Namespace: "default", Name: "example-ingress"}: {
+						ObjectMeta: metav1.ObjectMeta{Name: "example-ingress", Namespace: "default"},
+						Spec: networkingv1.IngressSpec{
+							IngressClassName: ptrTo("nginx"),
+							Rules: []networkingv1.IngressRule{
+								{
+									Host: "foo.example.com",
+									IngressRuleValue: networkingv1.IngressRuleValue{
+										HTTP: &networkingv1.HTTPIngressRuleValue{
+											Paths: []networkingv1.HTTPIngressPath{
+												{
+													Path:     "/",
+													PathType: &iPrefix,
+													Backend: networkingv1.IngressBackend{
+														Service: &networkingv1.IngressServiceBackend{
+															Name: "foo-app",
+															Port: networkingv1.ServiceBackendPort{Number: 80},
+														},
+													},
+												},
+												{
+													Path:     "/orders",
+													PathType: &iPrefix,
+													Backend: networkingv1.IngressBackend{
+														Service: &networkingv1.IngressServiceBackend{
+															Name: "foo-orders-app",
+															Port: networkingv1.ServiceBackendPort{Number: 80},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+								{
+									Host: "bar.example.com",
+									IngressRuleValue: networkingv1.IngressRuleValue{
+										HTTP: &networkingv1.HTTPIngressRuleValue{
+											Paths: []networkingv1.HTTPIngressPath{
+												{
+													Path:     "/",
+													PathType: &iPrefix,
+													Backend: networkingv1.IngressBackend{
+														Service: &networkingv1.IngressServiceBackend{
+															Name: "bar-app",
+															Port: networkingv1.ServiceBackendPort{Number: 80},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					{Namespace: "default", Name: "example-ingress-canary"}: {
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "example-ingress-canary",
+							Namespace: "default",
+							Annotations: map[string]string{
+								"nginx.ingress.kubernetes.io/canary":        "true",
+								"nginx.ingress.kubernetes.io/canary-weight": "30",
+							},
+						},
+						Spec: networkingv1.IngressSpec{
+							IngressClassName: ptrTo("nginx"),
+							Rules: []networkingv1.IngressRule{
+								{
+									Host: "bar.example.com",
+									IngressRuleValue: networkingv1.IngressRuleValue{
+										HTTP: &networkingv1.HTTPIngressRuleValue{
+											Paths: []networkingv1.HTTPIngressPath{
+												{
+													Path:     "/",
+													PathType: &iPrefix,
+													Backend: networkingv1.IngressBackend{
+														Service: &networkingv1.IngressServiceBackend{
+															Name: "bar-app-canary",
+															Port: networkingv1.ServiceBackendPort{Number: 80},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedGatewayResources: i2gw.GatewayResources{
+				Gateways: map[types.NamespacedName]gatewayv1.Gateway{
+					{Namespace: "default", Name: "nginx"}: {
+						ObjectMeta: metav1.ObjectMeta{Name: "nginx", Namespace: "default"},
+						Spec: gatewayv1.GatewaySpec{
+							GatewayClassName: "nginx",
+							Listeners: []gatewayv1.Listener{
+								{
+									Name:     "foo-example-com-http",
+									Port:     80,
+									Protocol: gatewayv1.HTTPProtocolType,
+									Hostname: ptrTo(gatewayv1.Hostname("foo.example.com")),
+								},
+								{
+									Name:     "bar-example-com-http",
+									Port:     80,
+									Protocol: gatewayv1.HTTPProtocolType,
+									Hostname: ptrTo(gatewayv1.Hostname("bar.example.com")),
+								},
+							},
+						},
+					},
+				},
+				HTTPRoutes: map[types.NamespacedName]gatewayv1.HTTPRoute{
+					{Namespace: "default", Name: "example-ingress-bar-example-com"}: {
+						ObjectMeta: metav1.ObjectMeta{Name: "example-ingress-bar-example-com", Namespace: "default"},
+						Spec: gatewayv1.HTTPRouteSpec{
+							CommonRouteSpec: gatewayv1.CommonRouteSpec{
+								ParentRefs: []gatewayv1.ParentReference{{
+									Name: "nginx",
+								}},
+							},
+							Hostnames: []gatewayv1.Hostname{"bar.example.com"},
+							Rules: []gatewayv1.HTTPRouteRule{{
+								Matches: []gatewayv1.HTTPRouteMatch{{
+									Path: &gatewayv1.HTTPPathMatch{
+										Type:  &gPathPrefix,
+										Value: ptrTo("/"),
+									},
+								}},
+								BackendRefs: []gatewayv1.HTTPBackendRef{
+									{
+										BackendRef: gatewayv1.BackendRef{
+											BackendObjectReference: gatewayv1.BackendObjectReference{
+												Name: "bar-app",
+												Port: ptrTo(gatewayv1.PortNumber(80)),
+											},
+											Weight: ptrTo[int32](70),
+										},
+									},
+									{
+										BackendRef: gatewayv1.BackendRef{
+											BackendObjectReference: gatewayv1.BackendObjectReference{
+												Name: "bar-app-canary",
+												Port: ptrTo(gatewayv1.PortNumber(80)),
+											},
+											Weight: ptrTo[int32](30),
 										},
 									},
 								},


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/ingress2gateway/blob/main/CONTRIBUTING.md). -->

<!-- The release notes and the kind will be used to generate the Changelog for the release. To make sure your contribution is recognized, please label this pull request according to what type of issue you are addressing and add the release notes when necessary (see ../CONTRIBUTING.md) -->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

**What this PR does / why we need it**:
Fixes #174 by applying canary only for entitled nginx rule groups, and fix canary evaluation when enabled.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #174

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Fix nginx canary annotation conversion
```
