### PR TITLE
Add translation for GKE Security Policy

### DIFF
--- a/pkg/i2gw/intermediate/provider_gce.go
+++ b/pkg/i2gw/intermediate/provider_gce.go
@@ -22,10 +22,14 @@ type GceGatewayIR struct {
 type GceHTTPRouteIR struct{}
 type GceServiceIR struct {
 	SessionAffinity *SessionAffinityConfig
+	SecurityPolicy  *SecurityPolicyConfig
 }
 type SessionAffinityConfig struct {
 	AffinityType string
 	CookieTTLSec *int64
+}
+type SecurityPolicyConfig struct {
+	Name string
 }
 
 func mergeGceGatewayIR(current, existing *GceGatewayIR) *GceGatewayIR {

--- a/pkg/i2gw/providers/gce/extensions/input_extensions.go
+++ b/pkg/i2gw/providers/gce/extensions/input_extensions.go
@@ -46,3 +46,9 @@ func BuildIRSessionAffinityConfig(beConfig *backendconfigv1.BackendConfig) *inte
 		CookieTTLSec: beConfig.Spec.SessionAffinity.AffinityCookieTtlSec,
 	}
 }
+
+func BuildIRSecurityPolicyConfig(beConfig *backendconfigv1.BackendConfig) *intermediate.SecurityPolicyConfig {
+	return &intermediate.SecurityPolicyConfig{
+		Name: beConfig.Spec.SecurityPolicy.Name,
+	}
+}

--- a/pkg/i2gw/providers/gce/extensions/output_extensions.go
+++ b/pkg/i2gw/providers/gce/extensions/output_extensions.go
@@ -31,3 +31,8 @@ func BuildBackendPolicySessionAffinityConfig(serviceIR intermediate.ProviderSpec
 	}
 	return &saConfig
 }
+
+func BuildBackendPolicySecurityPolicyConfig(serviceIR intermediate.ProviderSpecificServiceIR) *string {
+	securityPolicy := serviceIR.Gce.SecurityPolicy.Name
+	return &securityPolicy
+}

--- a/pkg/i2gw/providers/gce/gce_extensions.go
+++ b/pkg/i2gw/providers/gce/gce_extensions.go
@@ -148,6 +148,9 @@ func beConfigToGceServiceIR(beConfig *backendconfigv1.BackendConfig) intermediat
 	if beConfig.Spec.SessionAffinity != nil {
 		gceServiceIR.SessionAffinity = extensions.BuildIRSessionAffinityConfig(beConfig)
 	}
+	if beConfig.Spec.SecurityPolicy != nil {
+		gceServiceIR.SecurityPolicy = extensions.BuildIRSecurityPolicyConfig(beConfig)
+	}
 
 	return gceServiceIR
 }

--- a/pkg/i2gw/providers/gce/gce_extensions.go
+++ b/pkg/i2gw/providers/gce/gce_extensions.go
@@ -193,6 +193,9 @@ func addBackendPolicyIfConfigured(serviceNamespacedName types.NamespacedName, se
 	if serviceIR.Gce.SessionAffinity != nil {
 		backendPolicy.Spec.Default.SessionAffinity = extensions.BuildBackendPolicySessionAffinityConfig(serviceIR)
 	}
+	if serviceIR.Gce.SecurityPolicy != nil {
+		backendPolicy.Spec.Default.SecurityPolicy = extensions.BuildBackendPolicySecurityPolicyConfig(serviceIR)
+	}
 
 	return &backendPolicy
 }


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/ingress2gateway/blob/main/CONTRIBUTING.md). -->

<!-- The release notes and the kind will be used to generate the Changelog for the release. To make sure your contribution is recognized, please label this pull request according to what type of issue you are addressing and add the release notes when necessary (see ../CONTRIBUTING.md) -->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Adding a new feature for GKE Ingress and Gateway conversion.

**Which issue(s) this PR fixes**:
Adding more feature for #87.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Ingress2gateway now supports translating Cloud Armor security policy on GKE Ingress to GCPBackendPolicy on GKE Gateway.
```
