### PR TITLE
Add version command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,19 @@
 # Enable Go modules.
 export GO111MODULE=on
 
+# CMDPKG is the package path for cmd.  This allows us to propogate the git info
+# to the binary via LDFLAGS.
+CMDPKG := $(shell go list .)/cmd
+
+# Get the version string from git describe.
+# --tags: Use annotated tags.
+# --always: Fallback to commit hash if no tag is found.
+# --dirty: Append -dirty if the working directory has uncommitted changes.
+GIT_VERSION_STRING := $(shell git describe --tags --always --dirty 2>/dev/null)
+
+# Construct the LDFLAGS string to inject the version
+LDFLAGS := -ldflags="-X '$(CMDPKG).Version=$(GIT_VERSION_STRING)'"
+
 # Print the help menu.
 .PHONY: help
 help:
@@ -45,7 +58,7 @@ test: vet;$(info $(M)...Begin to run tests.)  @ ## Run tests.
 # Build the binary
 .PHONY: build
 build: vet;$(info $(M)...Build the binary.)  @ ## Build the binary.
-	go build -o ingress2gateway .
+	go build $(LDFLAGS) -o ingress2gateway .
 
 # Run static analysis.
 .PHONY: verify

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -48,6 +48,7 @@ func getKubeconfig() {
 func Execute() {
 	rootCmd := newRootCmd()
 	rootCmd.AddCommand(newPrintCommand())
+	rootCmd.AddCommand(versionCmd)
 	err := rootCmd.Execute()
 	if err != nil {
 		os.Exit(1)

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"runtime/debug"
+
+	"github.com/spf13/cobra"
+)
+
+// Version holds the version string (injected by ldflags during build).
+// It will be populated by `git describe --tags --always --dirty`.
+// Examples: "v0.4.0", "v0.4.0-5-gabcdef", "v0.4.0-5-gabcdef-dirty"
+var Version = "dev" // Default value if not built with linker flags
+
+// versionCmd represents the version command
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print the version number of ingress2gateway",
+	Long:  "Prints the build version details for ingress2gateway, including Git status information and Go version",
+	Run: func(_ *cobra.Command, _ []string) {
+		printVersion() // Call the helper function
+	},
+}
+
+// printVersion formats and prints the version information.
+func printVersion() {
+	fmt.Printf("ingress2gateway version: %s\n", Version)
+
+	// Print the golang version if it's available
+	buildInfo, ok := debug.ReadBuildInfo()
+	if ok && buildInfo != nil {
+		fmt.Printf("Built with Go version: %s\n", buildInfo.GoVersion)
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

Adds a `version` command that can be used to display the current binary version.

This is useful for users to be able to tell what version they are running, especially if installing via a package manager like homebrew.

Example:

    ./ingress2gateway version
    ingress2gateway version: v0.4.0
    Built with Go version: go1.24.2

* This is implemented via a combination of ldflags (to propogate the git tag info) and debug.BuildInfo (to get the golang version).
* This does not modify the CurrentVersion var in the i2gw package, but plan is to migrate that in a follow-up.

**Which issue(s) this PR fixes**:
Fixes #213

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
The version of the binary can now be printed with the `version` command (e.g. ingress2gateway version)
```
