### PR TITLE
Refactor CurrentVersion to use the git version string

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,9 @@
 # Enable Go modules.
 export GO111MODULE=on
 
-# CMDPKG is the package path for cmd.  This allows us to propogate the git info
+# I2GWPKG is the package path for i2gw.  This allows us to propogate the git info
 # to the binary via LDFLAGS.
-CMDPKG := $(shell go list .)/cmd
+I2GWPKG := $(shell go list .)/pkg/i2gw
 
 # Get the version string from git describe.
 # --tags: Use annotated tags.
@@ -29,7 +29,7 @@ CMDPKG := $(shell go list .)/cmd
 GIT_VERSION_STRING := $(shell git describe --tags --always --dirty 2>/dev/null)
 
 # Construct the LDFLAGS string to inject the version
-LDFLAGS := -ldflags="-X '$(CMDPKG).Version=$(GIT_VERSION_STRING)'"
+LDFLAGS := -ldflags="-X '$(I2GWPKG).Version=$(GIT_VERSION_STRING)'"
 
 # Print the help menu.
 .PHONY: help

--- a/cmd/print.go
+++ b/cmd/print.go
@@ -123,7 +123,7 @@ func (pr *PrintRunner) outputResult(gatewayResources []i2gw.GatewayResources) {
 			if gateway.Annotations == nil {
 				gateway.Annotations = make(map[string]string)
 			}
-			gateway.Annotations[i2gw.GeneratorAnnotationKey] = fmt.Sprintf("ingress2gateway-%s", i2gw.CurrentVersion)
+			gateway.Annotations[i2gw.GeneratorAnnotationKey] = fmt.Sprintf("ingress2gateway-%s", i2gw.Version)
 			err := pr.resourcePrinter.PrintObj(&gateway, os.Stdout)
 			if err != nil {
 				fmt.Printf("# Error printing %s Gateway: %v\n", gateway.Name, err)
@@ -138,7 +138,7 @@ func (pr *PrintRunner) outputResult(gatewayResources []i2gw.GatewayResources) {
 			if httpRoute.Annotations == nil {
 				httpRoute.Annotations = make(map[string]string)
 			}
-			httpRoute.Annotations[i2gw.GeneratorAnnotationKey] = fmt.Sprintf("ingress2gateway-%s", i2gw.CurrentVersion)
+			httpRoute.Annotations[i2gw.GeneratorAnnotationKey] = fmt.Sprintf("ingress2gateway-%s", i2gw.Version)
 			err := pr.resourcePrinter.PrintObj(&httpRoute, os.Stdout)
 			if err != nil {
 				fmt.Printf("# Error printing %s HTTPRoute: %v\n", httpRoute.Name, err)
@@ -153,7 +153,7 @@ func (pr *PrintRunner) outputResult(gatewayResources []i2gw.GatewayResources) {
 			if tlsRoute.Annotations == nil {
 				tlsRoute.Annotations = make(map[string]string)
 			}
-			tlsRoute.Annotations[i2gw.GeneratorAnnotationKey] = fmt.Sprintf("ingress2gateway-%s", i2gw.CurrentVersion)
+			tlsRoute.Annotations[i2gw.GeneratorAnnotationKey] = fmt.Sprintf("ingress2gateway-%s", i2gw.Version)
 			err := pr.resourcePrinter.PrintObj(&tlsRoute, os.Stdout)
 			if err != nil {
 				fmt.Printf("# Error printing %s TLSRoute: %v\n", tlsRoute.Name, err)
@@ -168,7 +168,7 @@ func (pr *PrintRunner) outputResult(gatewayResources []i2gw.GatewayResources) {
 			if tcpRoute.Annotations == nil {
 				tcpRoute.Annotations = make(map[string]string)
 			}
-			tcpRoute.Annotations[i2gw.GeneratorAnnotationKey] = fmt.Sprintf("ingress2gateway-%s", i2gw.CurrentVersion)
+			tcpRoute.Annotations[i2gw.GeneratorAnnotationKey] = fmt.Sprintf("ingress2gateway-%s", i2gw.Version)
 			err := pr.resourcePrinter.PrintObj(&tcpRoute, os.Stdout)
 			if err != nil {
 				fmt.Printf("# Error printing %s TCPRoute: %v\n", tcpRoute.Name, err)
@@ -183,7 +183,7 @@ func (pr *PrintRunner) outputResult(gatewayResources []i2gw.GatewayResources) {
 			if udpRoute.Annotations == nil {
 				udpRoute.Annotations = make(map[string]string)
 			}
-			udpRoute.Annotations[i2gw.GeneratorAnnotationKey] = fmt.Sprintf("ingress2gateway-%s", i2gw.CurrentVersion)
+			udpRoute.Annotations[i2gw.GeneratorAnnotationKey] = fmt.Sprintf("ingress2gateway-%s", i2gw.Version)
 			err := pr.resourcePrinter.PrintObj(&udpRoute, os.Stdout)
 			if err != nil {
 				fmt.Printf("# Error printing %s UDPRoute: %v\n", udpRoute.Name, err)
@@ -198,7 +198,7 @@ func (pr *PrintRunner) outputResult(gatewayResources []i2gw.GatewayResources) {
 			if referenceGrant.Annotations == nil {
 				referenceGrant.Annotations = make(map[string]string)
 			}
-			referenceGrant.Annotations[i2gw.GeneratorAnnotationKey] = fmt.Sprintf("ingress2gateway-%s", i2gw.CurrentVersion)
+			referenceGrant.Annotations[i2gw.GeneratorAnnotationKey] = fmt.Sprintf("ingress2gateway-%s", i2gw.Version)
 			err := pr.resourcePrinter.PrintObj(&referenceGrant, os.Stdout)
 			if err != nil {
 				fmt.Printf("# Error printing %s ReferenceGrant: %v\n", referenceGrant.Name, err)

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -20,13 +20,9 @@ import (
 	"fmt"
 	"runtime/debug"
 
+	"github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw"
 	"github.com/spf13/cobra"
 )
-
-// Version holds the version string (injected by ldflags during build).
-// It will be populated by `git describe --tags --always --dirty`.
-// Examples: "v0.4.0", "v0.4.0-5-gabcdef", "v0.4.0-5-gabcdef-dirty"
-var Version = "dev" // Default value if not built with linker flags
 
 // versionCmd represents the version command
 var versionCmd = &cobra.Command{
@@ -40,7 +36,7 @@ var versionCmd = &cobra.Command{
 
 // printVersion formats and prints the version information.
 func printVersion() {
-	fmt.Printf("ingress2gateway version: %s\n", Version)
+	fmt.Printf("ingress2gateway version: %s\n", i2gw.Version)
 
 	// Print the golang version if it's available
 	buildInfo, ok := debug.ReadBuildInfo()

--- a/pkg/i2gw/ingress2gateway.go
+++ b/pkg/i2gw/ingress2gateway.go
@@ -30,7 +30,10 @@ import (
 
 const GeneratorAnnotationKey = "gateway.networking.k8s.io/generator"
 
-var CurrentVersion = "0.4.0"
+// Version holds the version string (injected by ldflags during build).
+// It will be populated by `git describe --tags --always --dirty`.
+// Examples: "v0.4.0", "v0.4.0-5-gabcdef", "v0.4.0-5-gabcdef-dirty"
+var Version = "dev" // Default value if not built with linker flags
 
 func ToGatewayAPIResources(ctx context.Context, namespace string, inputFile string, providers []string, providerSpecificFlags map[string]map[string]string) ([]GatewayResources, map[string]string, error) {
 	var clusterClient client.Client


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

* Previously the git version string was plumbed to cmd.Version via the linker and i2gw had a hardcoded version
* Now the linker propogates the version string to i2gw and the cmd package imports it from there
* Renames `CurrentVersion` to just `Version`
* This has a few effects:
  1. You no longer need to manually update i2gw.CurrentVersion whenever there is a release.  Simply tagging the release will work.
  2. The generator annotations (gateway.networking.k8s.io/generator) will now use the git version string instead instead of just the hardcoded value.  This means that during local development you will see something like `"ingress2gateway-v0.4.0-5-gabcdef-dirty"` in your generated annotations, letting you know exactly what local commit you were using when you generated that Gateway.  However, end users who download a release or install via a package manager should **not** see any difference in behavior.

This PR is a follow-up to #216

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
