### PR TITLE
Fix print command instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,17 +77,17 @@ brew install ingress2gateway
 
 Ingress2gateway reads Ingress resources and/or provider-specifc CRDs from a Kubernetes
 cluster or a file. It will output the equivalent Gateway API resources in a YAML/JSON
-format to stdout. To run ingress2gateway with default options simply run:
+format to stdout.  The simplest case is to convert all ingresses from one provider (in this example we use ingress-nginx):
 
 ```shell
-./ingress2gateway print
+./ingress2gateway print --providers=ingress-nginx
 ```
 
 The above command will:
 
 1. Read your Kube config file to extract the cluster credentials and the current
    active namespace.
-1. Search for ingresses and provider-specific resources in that namespace.
+1. Search for ingress-nginx resources in that namespace.
 1. Convert them to Gateway-API resources (Currently only Gateways and HTTPRoutes).
 
 ## Options
@@ -103,7 +103,7 @@ The above command will:
 | openapi3-gateway-class-name     |                         | No       | Provider-specific: openapi3. The name of the gateway class to use in the Gateways. |
 | openapi3-gateway-tls-secret     |                         | No       | Provider-specific: openapi3. The name of the secret for the TLS certificate references in the Gateways. |
 | output         | yaml                    | No       | The output format, either yaml or json.                       |
-| providers      | all supported providers | Yes       | Comma-separated list of providers. |
+| providers      |  | Yes       | Comma-separated list of providers. |
 | kubeconfig     |                         | No       | The kubeconfig file to use when talking to the cluster. If the flag is not set, a set of standard locations can be searched for an existing kubeconfig file. |
 
 ## Conversion of Ingress resources to Gateway API


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:

Fixes the example `print` command in the README, which currently will print this:

```
./ingress2gateway print
Error: required flag(s) "providers" not set
Usage:
  ingress2gateway print [flags]
...
```

* v0.3.0 made the `--providers` print command required, however the README wasn't updated
* Updates the example print command to use --providers=ingress-nginx since at least one provider *must* be specified
* Removes the default option of providers in the table in the README since it no longer exists.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
