### PR TITLE
Sort the names of the names of the providers in the print command

### DIFF
--- a/pkg/i2gw/ingress2gateway.go
+++ b/pkg/i2gw/ingress2gateway.go
@@ -19,6 +19,7 @@ package i2gw
 import (
 	"context"
 	"fmt"
+	"sort"
 
 	"github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw/notifications"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -136,6 +137,8 @@ func GetSupportedProviders() []string {
 	for key := range ProviderConstructorByName {
 		supportedProviders = append(supportedProviders, string(key))
 	}
+	// Sort the provider names for consistent output.
+	sort.Strings(supportedProviders)
 	return supportedProviders
 }
 


### PR DESCRIPTION
**What type of PR is this?**

Add one of the following kinds:
/kind cleanup

**What this PR does / why we need it**:

* Previously the help string for `print --providers` had a non-deterministic ordering since it is generated from map keys.
* This will be helpful in tackling #162

*Before (point in time example)*
`
      --providers strings                    If present, the tool will try to convert only resources related to the specified providers, supported values are [kong openapi3 apisix cilium gce ingress-nginx istio].
`

*After*
`
      --providers strings                    If present, the tool will try to convert only resources related to the specified providers, supported values are [apisix cilium gce ingress-nginx istio kong openapi3].
`

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
