### PR TITLE
Automatically generate flag docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ brew install ingress2gateway
    make build
    ```
 
-## Usage
+## Basic Usage
 
 Ingress2gateway reads Ingress resources and/or provider-specifc CRDs from a Kubernetes
 cluster or a file. It will output the equivalent Gateway API resources in a YAML/JSON
@@ -141,6 +141,216 @@ routing rules.
 | `rules[].http.paths[].path`     | This field translates to a HTTPRoute `rules[].matches[].path.value` configuration.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
 | `rules[].http.paths[].pathType` | This field translates to a HTTPRoute `rules[].matches[].path.type` configuration. Ingress `Exact` = HTTPRoute `Exact` match. Ingress `Prefix` = HTTPRoute `PathPrefix` match.                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | `rules[].http.paths[].backend`  | The backend specified here will be translated to a HTTPRoute `rules[].backendRefs[]` element.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+
+
+<!--- BEGIN GENERATED DOCS -->
+### `ingress2gateway completion`
+
+**Usage:** `ingress2gateway completion`
+
+**Description:**
+
+Generate the autocompletion script for ingress2gateway for the specified shell.
+See each sub-command's help for details on how to use the generated script.
+
+
+**Available Subcommands:**
+| Command | Description |
+| ------- | ----------- |
+| `bash` | Generate the autocompletion script for bash |
+| `fish` | Generate the autocompletion script for fish |
+| `powershell` | Generate the autocompletion script for powershell |
+| `zsh` | Generate the autocompletion script for zsh |
+
+
+---
+### `ingress2gateway completion bash`
+
+**Usage:** `ingress2gateway completion bash`
+
+**Description:**
+
+Generate the autocompletion script for the bash shell.
+
+This script depends on the 'bash-completion' package.
+If it is not installed already, you can install it via your OS's package manager.
+
+To load completions in your current shell session:
+
+	source <(ingress2gateway completion bash)
+
+To load completions for every new session, execute once:
+
+#### Linux:
+
+	ingress2gateway completion bash > /etc/bash_completion.d/ingress2gateway
+
+#### macOS:
+
+	ingress2gateway completion bash > $(brew --prefix)/etc/bash_completion.d/ingress2gateway
+
+You will need to start a new shell for this setup to take effect.
+
+
+**Flags:**
+| Flag | Default Value | Required | Description |
+| ---- | ------------- | -------- | ----------- |
+| `--no-descriptions` | `false` | No | disable completion descriptions |
+
+**Inherited Flags:**
+| Flag | Default Value | Required | Description |
+| ---- | ------------- | -------- | ----------- |
+| `--kubeconfig` | ` `  | No | The kubeconfig file to use when talking to the cluster. If the flag is not set, a set of standard locations can be searched for an existing kubeconfig file. |
+
+
+---
+### `ingress2gateway completion fish`
+
+**Usage:** `ingress2gateway completion fish [flags]`
+
+**Description:**
+
+Generate the autocompletion script for the fish shell.
+
+To load completions in your current shell session:
+
+	ingress2gateway completion fish | source
+
+To load completions for every new session, execute once:
+
+	ingress2gateway completion fish > ~/.config/fish/completions/ingress2gateway.fish
+
+You will need to start a new shell for this setup to take effect.
+
+
+**Flags:**
+| Flag | Default Value | Required | Description |
+| ---- | ------------- | -------- | ----------- |
+| `--no-descriptions` | `false` | No | disable completion descriptions |
+
+**Inherited Flags:**
+| Flag | Default Value | Required | Description |
+| ---- | ------------- | -------- | ----------- |
+| `--kubeconfig` | ` `  | No | The kubeconfig file to use when talking to the cluster. If the flag is not set, a set of standard locations can be searched for an existing kubeconfig file. |
+
+
+---
+### `ingress2gateway completion help`
+
+**Usage:** `ingress2gateway completion help [command]`
+
+**Description:**
+
+Help provides help for any command in the application.
+Simply type completion help [path to command] for full details.
+
+**Flags:** None
+
+---
+### `ingress2gateway completion powershell`
+
+**Usage:** `ingress2gateway completion powershell [flags]`
+
+**Description:**
+
+Generate the autocompletion script for powershell.
+
+To load completions in your current shell session:
+
+	ingress2gateway completion powershell | Out-String | Invoke-Expression
+
+To load completions for every new session, add the output of the above command
+to your powershell profile.
+
+
+**Flags:**
+| Flag | Default Value | Required | Description |
+| ---- | ------------- | -------- | ----------- |
+| `--no-descriptions` | `false` | No | disable completion descriptions |
+
+**Inherited Flags:**
+| Flag | Default Value | Required | Description |
+| ---- | ------------- | -------- | ----------- |
+| `--kubeconfig` | ` `  | No | The kubeconfig file to use when talking to the cluster. If the flag is not set, a set of standard locations can be searched for an existing kubeconfig file. |
+
+
+---
+### `ingress2gateway completion zsh`
+
+**Usage:** `ingress2gateway completion zsh [flags]`
+
+**Description:**
+
+Generate the autocompletion script for the zsh shell.
+
+If shell completion is not already enabled in your environment you will need
+to enable it.  You can execute the following once:
+
+	echo "autoload -U compinit; compinit" >> ~/.zshrc
+
+To load completions in your current shell session:
+
+	source <(ingress2gateway completion zsh)
+
+To load completions for every new session, execute once:
+
+#### Linux:
+
+	ingress2gateway completion zsh > "${fpath[1]}/_ingress2gateway"
+
+#### macOS:
+
+	ingress2gateway completion zsh > $(brew --prefix)/share/zsh/site-functions/_ingress2gateway
+
+You will need to start a new shell for this setup to take effect.
+
+
+**Flags:**
+| Flag | Default Value | Required | Description |
+| ---- | ------------- | -------- | ----------- |
+| `--no-descriptions` | `false` | No | disable completion descriptions |
+
+**Inherited Flags:**
+| Flag | Default Value | Required | Description |
+| ---- | ------------- | -------- | ----------- |
+| `--kubeconfig` | ` `  | No | The kubeconfig file to use when talking to the cluster. If the flag is not set, a set of standard locations can be searched for an existing kubeconfig file. |
+
+### `ingress2gateway print`
+
+**Usage:** `ingress2gateway print [flags]`
+
+**Description:**
+
+Prints Gateway API objects generated from ingress and provider-specific resources.
+
+**Flags:**
+| Flag | Default Value | Required | Description |
+| ---- | ------------- | -------- | ----------- |
+| `-A`, `--all-namespaces` | `false` | No | If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even
+if specified with --namespace. |
+| `--input-file` | ` `  | No | Path to the manifest file. When set, the tool will read ingresses from the file instead of reading from the cluster. Supported files are yaml and json. |
+| `-n`, `--namespace` | ` `  | No | If present, the namespace scope for this CLI request. |
+| `--openapi3-backend` | ` `  | No | Provider-specific: openapi3. The name of the backend service to use in the HTTPRoutes. |
+| `--openapi3-gateway-class-name` | ` `  | No | Provider-specific: openapi3. The name of the gateway class to use in the Gateways. |
+| `--openapi3-gateway-tls-secret` | ` `  | No | Provider-specific: openapi3. The name of the secret for the TLS certificate references in the Gateways. |
+| `-o`, `--output` | `yaml` | No | Output format. One of: (json, yaml). |
+| `--providers` | `[]` | Yes | If present, the tool will try to convert only resources related to the specified providers, supported values are [apisix cilium gce ingress-nginx istio kong openapi3]. |
+
+**Inherited Flags:**
+| Flag | Default Value | Required | Description |
+| ---- | ------------- | -------- | ----------- |
+| `--kubeconfig` | ` `  | No | The kubeconfig file to use when talking to the cluster. If the flag is not set, a set of standard locations can be searched for an existing kubeconfig file. |
+
+### `ingress2gateway version`
+
+**Usage:** `ingress2gateway version`
+
+**Description:**
+
+Prints the build version details for ingress2gateway, including Git status information and Go version
+
+**Flags:** None
+<!--- END GENERATED DOCS -->
 
 ## Get Involved
 

--- a/cmd/generatedocs.go
+++ b/cmd/generatedocs.go
@@ -1,0 +1,230 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// newGenerateDocsCmd creates a command for generating documentation files.
+// This command is hidden from the regular help output because it should only be used by the hack/generate-cli-doc.sh script.
+// It generates Markdown documentation for all commands and subcommands of the provided root command.
+func newGenerateDocsCmd(rootCmd *cobra.Command) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "generate-docs",
+		Short:  "Generate documentation files",
+		Hidden: true, // Hide from regular help output
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			for _, c := range rootCmd.Commands() {
+				if c.Hidden {
+					continue // Skip hidden commands
+				}
+				if c.Name() == "help" {
+					continue // Skip help command
+				}
+				err := generateRecursiveCommandDocs(c, cmd.OutOrStdout())
+				if err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	}
+	return cmd
+}
+
+// generateRecursiveCommandDocs generates Markdown for a command and its subcommands.
+func generateRecursiveCommandDocs(cmd *cobra.Command, w io.Writer) error {
+	// Generate docs for the current command first
+	if err := generateCommandDocs(cmd, w); err != nil {
+		return err
+	}
+
+	// Recursively generate for subcommands
+	subCmds := cmd.Commands()
+	sort.Slice(subCmds, func(i, j int) bool { // Sort for consistent order
+		return subCmds[i].Name() < subCmds[j].Name()
+	})
+	for _, subCmd := range subCmds {
+		fmt.Fprintln(w, "\n---") // Add separator
+		if err := generateRecursiveCommandDocs(subCmd, w); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func generateCommandDocs(cmd *cobra.Command, w io.Writer) error {
+	cmd.InitDefaultHelpCmd()     // Ensure help command is initialized
+	cmd.InitDefaultVersionFlag() // Ensure version flag is initialized
+
+	// Print Header
+	fmt.Fprintf(w, "### `%s`\n\n", cmd.CommandPath())
+
+	// Handle Usage
+	// Show usage if the command itself is runnable OR if it has subcommands
+	if cmd.Runnable() || cmd.HasSubCommands() {
+		fmt.Fprintf(w, "**Usage:** `%s`\n\n", cmd.UseLine())
+	}
+
+	// Handle Aliases
+	if len(cmd.Aliases) > 0 {
+		fmt.Fprintf(w, "**Aliases:** `%s`\n\n", strings.Join(cmd.Aliases, "`, `"))
+	}
+
+	// Handle Description
+	description := cmd.Long
+	if description == "" {
+		description = cmd.Short
+	}
+	if description != "" {
+		fmt.Fprintf(w, "**Description:**\n\n%s\n\n", description)
+	}
+
+	// Handle Subcommands
+	if cmd.HasSubCommands() {
+		fmt.Fprintln(w, "**Available Subcommands:**")
+		fmt.Fprintln(w, "| Command | Description |")
+		fmt.Fprintln(w, "| ------- | ----------- |")
+
+		subCmds := cmd.Commands()
+		sort.Slice(subCmds, func(i, j int) bool { // Sort for consistent output
+			return subCmds[i].Name() < subCmds[j].Name()
+		})
+
+		for _, subCmd := range subCmds {
+			// Only list available (non-hidden, non-help) commands
+			if subCmd.IsAvailableCommand() {
+				fmt.Fprintf(w, "| `%s` | %s |\n", subCmd.Name(), subCmd.Short)
+			}
+		}
+		// Newline
+		fmt.Fprintln(w, "")
+	}
+
+	// Handle Flags
+	// Check if *any* flags (local or inherited) are defined for the command
+	if cmd.HasAvailableFlags() {
+		fmt.Fprintln(w, "**Flags:**")
+		if err := generateFlagTable(cmd, w); err != nil {
+			return fmt.Errorf("error generating flag table for %s: %w", cmd.Name(), err)
+		}
+		fmt.Fprintln(w, "")
+	} else if !cmd.HasSubCommands() {
+		// Only print "Flags: None" if it's a leaf command with no flags *and* no subcommands
+		fmt.Fprintln(w, "**Flags:** None")
+	}
+
+	// Handle Examples
+	if cmd.Example != "" {
+		fmt.Fprintf(w, "**Example:**\n\n```\n%s\n```\n\n", cmd.Example)
+	}
+	return nil
+}
+
+// generateFlagTable generates a Markdown table for a command's flags.
+// It is a wrapper around generateFlagTable to explicitly handle both local and inherited flags.
+func generateFlagTable(cmd *cobra.Command, w io.Writer) error {
+	if err := generateFlagTableHelper(cmd.LocalFlags(), cmd.Name(), false /*inherited*/, w); err != nil {
+		return err
+	}
+
+	if err := generateFlagTableHelper(cmd.InheritedFlags(), cmd.Name(), true /*inherited*/, w); err != nil {
+		return err
+	}
+	return nil
+}
+
+// generateFlagTableHelper generates a Markdown table for a command's flags,
+// cmdName is passed in explicitly since it cannot be obtained from the flag set.
+// inherited is used to generate a separate header for inherited flags.
+func generateFlagTableHelper(flagSet *pflag.FlagSet, cmdName string, inherited bool, w io.Writer) error {
+	// Check if there are any flags to print.
+	flagSlice := make([]*pflag.Flag, 0)
+	flagSet.VisitAll(func(flag *pflag.Flag) {
+		// Filter out the standard help flag unless documenting the help command itself
+		if flag.Name == "help" && flag.Usage == "help for "+cmdName {
+			if cmdName != "help" {
+				return // Skip standard help flag
+			}
+		}
+		// Filter out test flags if necessary (e.g., if running doc gen via `go test`)
+		if strings.HasPrefix(flag.Name, "test.") {
+			return
+		}
+		flagSlice = append(flagSlice, flag)
+	})
+
+	if len(flagSlice) == 0 {
+		return nil // No printable flags found
+	}
+
+	// Sort flags by name for consistent output.
+	sort.Slice(flagSlice, func(i, j int) bool {
+		return flagSlice[i].Name < flagSlice[j].Name
+	})
+
+	// Print inherited flags in a separate section.
+	if inherited {
+		fmt.Fprintln(w, "\n**Inherited Flags:**")
+	}
+
+	// Print Header.
+	fmt.Fprintln(w, "| Flag | Default Value | Required | Description |")
+	fmt.Fprintln(w, "| ---- | ------------- | -------- | ----------- |")
+
+	// Print table rows.
+	for _, flag := range flagSlice {
+		required := "No"
+		// This looks weird but this actually how Cobra marks required flags.
+		if _, ok := flag.Annotations[cobra.BashCompOneRequiredFlag]; ok {
+			required = "Yes"
+		}
+
+		defaultValue := flag.DefValue
+		if defaultValue == "" {
+			// Represent empty default clearly in Markdown
+			defaultValue = "` ` "
+		} else {
+			// Escape potential pipes and wrap default value in backticks
+			defaultValue = fmt.Sprintf("`%s`", strings.ReplaceAll(defaultValue, "|", "\\|"))
+		}
+
+		// Escape pipes in description
+		description := strings.ReplaceAll(flag.Usage, "|", "\\|")
+
+		// Format flag name (including shorthand if available and not deprecated)
+		flagName := fmt.Sprintf("`--%s`", flag.Name)
+		if flag.Shorthand != "" && flag.ShorthandDeprecated == "" {
+			flagName = fmt.Sprintf("`-%s`, %s", flag.Shorthand, flagName)
+		}
+
+		fmt.Fprintf(w, "| %s | %s | %s | %s |\n",
+			flagName,
+			defaultValue,
+			required,
+			description,
+		)
+	}
+	return nil
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -49,6 +49,8 @@ func Execute() {
 	rootCmd := newRootCmd()
 	rootCmd.AddCommand(newPrintCommand())
 	rootCmd.AddCommand(versionCmd)
+	// This command is used to generate docs for the other commands, it must be added last.
+	rootCmd.AddCommand(newGenerateDocsCmd(rootCmd))
 	err := rootCmd.Execute()
 	if err != nil {
 		os.Exit(1)

--- a/hack/generate-cli-docs.sh
+++ b/hack/generate-cli-docs.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+
+# Copyright 2025 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Runs the 'generate-docs' command from the ingress2gateway binary
+# and updates the README.md file with the generated documentation.
+
+# Exit immediately if a command exits with a non-zero status.
+set -e
+# Treat unset variables as an error when substituting.
+set -u
+# Pipe failures should exit the script
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+README_FILE="${REPO_ROOT}/README.md"
+BINARY_PATH="${REPO_ROOT}/ingress2gateway"
+# This marker in the README file indicates where to insert the generated documentation.
+MARKER_START="<!--- BEGIN GENERATED DOCS -->"
+MARKER_END="<!--- END GENERATED DOCS -->"
+# ./ingress2gateway generate-docs is the command to generate these docs.
+DOCS_COMMAND="${BINARY_PATH} generate-docs"
+TMP_DOCS_FILE=$(mktemp) # Create a temporary file for docs output
+
+# Ensure the script runs from the repo root
+cd "${REPO_ROOT}"
+
+# Cleanup function to remove temporary file on exit
+cleanup() {
+  rm -f "$TMP_DOCS_FILE"
+}
+trap cleanup EXIT
+
+# Generate documentation
+echo ">>> Generating documentation using '${DOCS_COMMAND}'..."
+if ! ${DOCS_COMMAND} > "$TMP_DOCS_FILE"; then
+    echo "ERROR: Failed to generate documentation." >&2
+    # Optional: Print captured output for debugging
+    # cat "$TMP_DOCS_FILE" >&2
+    exit 1
+fi
+echo ">>> Documentation generated successfully."
+
+# Check if markers exist in README
+if ! grep -qF "$MARKER_START" "$README_FILE" || ! grep -qF "$MARKER_END" "$README_FILE"; then
+    echo "ERROR: Start ('$MARKER_START') or end ('$MARKER_END') marker not found in $README_FILE." >&2
+    echo "Please add the markers around the section to be updated in $README_FILE." >&2
+    exit 1
+fi
+
+echo ">>> Updating $README_FILE..."
+
+# Use awk to replace content between markers
+awk -v start_marker="$MARKER_START" \
+    -v end_marker="$MARKER_END" \
+    -v docs_file="$TMP_DOCS_FILE" '
+BEGIN { printing=1; found_start=0 }
+# Match the start marker line
+$0 == start_marker {
+    print; # Print the start marker line itself
+    # Print the content from the generated docs file
+    while ((getline line < docs_file) > 0) {
+        print line
+    }
+    close(docs_file);
+    printing=0; # Stop printing original lines between markers
+    found_start=1;
+    next; # Move to next line of README input
+}
+# Match the end marker line
+$0 == end_marker {
+    if (found_start == 0) {
+        print "Error: End marker found before start marker." > "/dev/stderr"
+        exit 1
+    }
+    print; # Print the end marker line itself
+    printing=1; # Resume printing original lines
+    next; # Move to next line of README input
+}
+# Print lines only if printing is enabled (outside the markers)
+{ if (printing) print }
+' "$README_FILE" > "$README_FILE.tmp" && mv "$README_FILE.tmp" "$README_FILE"
+# Check awk exit status (though awk script has basic checks)
+if [ $? -ne 0 ]; then
+    echo "ERROR: awk command failed while updating $README_FILE." >&2
+    exit 1
+fi
+
+echo ">>> $README_FILE updated successfully."
+exit 0

--- a/hack/verify-readme.sh
+++ b/hack/verify-readme.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+# Copyright 2025 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Verifies that the auto-generated documentation sections in README.md are up-to-date.
+
+# Exit immediately if a command exits with a non-zero status.
+set -e
+
+# Pipe failures should exit the script
+set -o pipefail
+
+echo "+++ Verifying README.md documentation..."
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+README_FILE="${REPO_ROOT}/README.md"
+UPDATE_SCRIPT="${SCRIPT_DIR}/generate-cli-docs.sh" # Path to your update script
+
+# Ensure the script runs from the repository root for consistent paths
+cd "${REPO_ROOT}"
+
+# 1. Ensure the update script exists and is executable
+if [ ! -f "$UPDATE_SCRIPT" ]; then
+    echo "ERROR: Documentation update script not found at $UPDATE_SCRIPT" >&2
+    exit 1
+fi
+if [ ! -x "$UPDATE_SCRIPT" ]; then
+    echo "ERROR: Documentation update script is not executable: $UPDATE_SCRIPT" >&2
+    exit 1
+fi
+
+# 2. Run the update script to potentially regenerate the docs in place.
+#    We capture output to avoid polluting CI logs unless the script fails.
+echo "--- Running documentation update script to ensure consistency..."
+update_output=$(mktemp)
+if ! "$UPDATE_SCRIPT" > "$update_output" 2>&1; then
+    echo "ERROR: Documentation update script '${UPDATE_SCRIPT}' failed. Output:" >&2
+    cat "$update_output" >&2
+    rm "$update_output"
+    exit 1
+fi
+rm "$update_output"
+echo "--- Documentation update script finished."
+
+# 3. Check for differences in README.md using git diff.
+#    'git diff --exit-code' returns 0 if there are no differences, non-zero otherwise.
+echo "--- Checking for changes in ${README_FILE}..."
+if git diff --quiet HEAD -- "${README_FILE}"; then
+    echo "+++ SUCCESS: ${README_FILE} documentation is up-to-date."
+    exit 0
+else
+    echo "--- ERROR: ${README_FILE} documentation is out-of-date." >&2
+    echo "--- Please run './hack/generate-cli-docs.sh' (or 'make docs')" >&2
+    echo "--- and commit the changes to ${README_FILE}." >&2
+    exit 1
+fi

--- a/pkg/i2gw/ingress2gateway.go
+++ b/pkg/i2gw/ingress2gateway.go
@@ -19,6 +19,7 @@ package i2gw
 import (
 	"context"
 	"fmt"
+	"sort"
 
 	"github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw/notifications"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -139,6 +140,8 @@ func GetSupportedProviders() []string {
 	for key := range ProviderConstructorByName {
 		supportedProviders = append(supportedProviders, string(key))
 	}
+	// Sort the provider names for consistent output.
+	sort.Strings(supportedProviders)
 	return supportedProviders
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation
/kind feature

**What this PR does / why we need it**:

Automatically generate the docs for the entire CLI surface and inject it into the README.

This PR is somewhat large so i've separated it into 3 commits so it's easier to review.  It also involved a fair amount of *vibe coding* so i'm not particularly attached to the implementation 😄 

There are a few new things being introduced here:

1. A _hidden_ `generate-docs` command which does the heavy lifting of parsing the Cobra command tree and generating the relevant sections and tables.  Cobra actually has some built in logic by way of `GenMarkdownTree()`, but after messing with it a bunch I don't think it's a good fit here.  Mainly it generates one file per command+subcommand, and it doesn't allow you to do any custom formatting (like a table).

2. A `hack/generate-cli-docs.sh` script which runs `generate-docs` and then injects it into the README using some begin/end markers specified via HTML comments.

3. a `hack/verify-readme.sh` script which verifies that the README is up-to-date when contributors submit a PR.

NOTE: This PR also depends on #219 being merged (but currently that diff is included here).

**Which issue(s) this PR fixes**:
Fixes #162 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
