### PR TITLE
Fix golint warnings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,8 +15,6 @@ linters:
   - govet
   - misspell
   - exportloopref
-  disable:
-  - scopelint
   disable-all: false
   presets:
   - bugs
@@ -31,7 +29,7 @@ linters-settings:
     min-confidence: 0.9
   govet:
     # report about shadowed variables
-    check-shadowing: true
+    shadow: true
   misspell:
     locale: US
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

Fixes the following two golint warnings:
```
level=warning msg="[config_reader] The configuration option `linters.govet.check-shadowing` is deprecated. Please enable `shadow` instead, if you are not using `enable-all`."
level=warning msg="[lintersdb] The linter \"scopelint\" is deprecated (step 2) and deactivated. It should be removed from the list of disabled linters. https://golangci-lint.run/product/roadmap/#linter-deprecation-cycle"
```


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
