### PR TITLE
Add support for named ports

### DIFF
--- a/pkg/i2gw/provider.go
+++ b/pkg/i2gw/provider.go
@@ -118,7 +118,7 @@ type GatewayResources struct {
 //
 // Different FeatureParsers will run in undetermined order. The function must
 // modify / create only the required fields of the gateway resources and nothing else.
-type FeatureParser func([]networkingv1.Ingress, *intermediate.IR) field.ErrorList
+type FeatureParser func([]networkingv1.Ingress, map[types.NamespacedName]map[string]int32, *intermediate.IR) field.ErrorList
 
 var providerSpecificFlagDefinitions = providerSpecificFlags{
 	flags: make(map[ProviderName]map[string]ProviderSpecificFlag),

--- a/pkg/i2gw/providers/apisix/converter.go
+++ b/pkg/i2gw/providers/apisix/converter.go
@@ -49,14 +49,14 @@ func (c *resourcesToIRConverter) convertToIR(storage *storage) (intermediate.IR,
 	}
 	// Convert plain ingress resources to gateway resources, ignoring all
 	// provider-specific features.
-	ir, errs := common.ToIR(ingressList, c.implementationSpecificOptions)
+	ir, errs := common.ToIR(ingressList, storage.ServicePorts, c.implementationSpecificOptions)
 	if len(errs) > 0 {
 		return intermediate.IR{}, errs
 	}
 
 	for _, parseFeatureFunc := range c.featureParsers {
 		// Apply the feature parsing function to the gateway resources, one by one.
-		parseErrs := parseFeatureFunc(ingressList, &ir)
+		parseErrs := parseFeatureFunc(ingressList, storage.ServicePorts, &ir)
 		// Append the parsing errors to the error list.
 		errs = append(errs, parseErrs...)
 	}

--- a/pkg/i2gw/providers/apisix/http_to_https.go
+++ b/pkg/i2gw/providers/apisix/http_to_https.go
@@ -29,7 +29,7 @@ import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
-func httpToHTTPSFeature(ingresses []networkingv1.Ingress, ir *intermediate.IR) field.ErrorList {
+func httpToHTTPSFeature(ingresses []networkingv1.Ingress, _ map[types.NamespacedName]map[string]int32, ir *intermediate.IR) field.ErrorList {
 	var errs field.ErrorList
 	httpToHTTPSAnnotation := apisixAnnotation("http-to-https")
 	ruleGroups := common.GetRuleGroups(ingresses)

--- a/pkg/i2gw/providers/apisix/http_to_https_test.go
+++ b/pkg/i2gw/providers/apisix/http_to_https_test.go
@@ -266,7 +266,7 @@ func Test_httpToHttpsFeature(t *testing.T) {
 				},
 			}
 
-			errs := httpToHTTPSFeature(ingresses, ir)
+			errs := httpToHTTPSFeature(ingresses, map[types.NamespacedName]map[string]int32{}, ir)
 
 			if len(errs) != len(tc.expectedError) {
 				t.Errorf("expected %d errors, got %d", len(tc.expectedError), len(errs))

--- a/pkg/i2gw/providers/apisix/resource_reader.go
+++ b/pkg/i2gw/providers/apisix/resource_reader.go
@@ -45,6 +45,12 @@ func (r *resourceReader) readResourcesFromCluster(ctx context.Context) (*storage
 		return nil, err
 	}
 	storage.Ingresses = ingresses
+
+	services, err := common.ReadServicesFromCluster(ctx, r.conf.Client)
+	if err != nil {
+		return nil, err
+	}
+	storage.ServicePorts = common.GroupServicePortsByPortName(services)
 	return storage, nil
 }
 
@@ -52,10 +58,16 @@ func (r *resourceReader) readResourcesFromFile(filename string) (*storage, error
 	// read apisix related resources from file.
 	storage := newResourcesStorage()
 
-	ingresses, err := common.ReadIngressesFromFile(filename, r.conf.Namespace, sets.New[string](ApisixIngressClass))
+	ingresses, err := common.ReadIngressesFromFile(filename, r.conf.Namespace, sets.New(ApisixIngressClass))
 	if err != nil {
 		return nil, err
 	}
 	storage.Ingresses = ingresses
+
+	services, err := common.ReadServicesFromFile(filename, r.conf.Namespace)
+	if err != nil {
+		return nil, err
+	}
+	storage.ServicePorts = common.GroupServicePortsByPortName(services)
 	return storage, nil
 }

--- a/pkg/i2gw/providers/apisix/storage.go
+++ b/pkg/i2gw/providers/apisix/storage.go
@@ -22,11 +22,13 @@ import (
 )
 
 type storage struct {
-	Ingresses map[types.NamespacedName]*networkingv1.Ingress
+	Ingresses    map[types.NamespacedName]*networkingv1.Ingress
+	ServicePorts map[types.NamespacedName]map[string]int32
 }
 
 func newResourcesStorage() *storage {
 	return &storage{
-		Ingresses: map[types.NamespacedName]*networkingv1.Ingress{},
+		Ingresses:    map[types.NamespacedName]*networkingv1.Ingress{},
+		ServicePorts: map[types.NamespacedName]map[string]int32{},
 	}
 }

--- a/pkg/i2gw/providers/cilium/converter.go
+++ b/pkg/i2gw/providers/cilium/converter.go
@@ -49,14 +49,14 @@ func (c *resourcesToIRConverter) convertToIR(storage *storage) (intermediate.IR,
 	}
 	// Convert plain ingress resources to gateway resources, ignoring all
 	// provider-specific features.
-	ir, errs := common.ToIR(ingressList, c.implementationSpecificOptions)
+	ir, errs := common.ToIR(ingressList, storage.ServicePorts, c.implementationSpecificOptions)
 	if len(errs) > 0 {
 		return intermediate.IR{}, errs
 	}
 
 	for _, parseFeatureFunc := range c.featureParsers {
 		// Apply the feature parsing function to the gateway resources, one by one.
-		parseErrs := parseFeatureFunc(ingressList, &ir)
+		parseErrs := parseFeatureFunc(ingressList, storage.ServicePorts, &ir)
 		// Append the parsing errors to the error list.
 		errs = append(errs, parseErrs...)
 	}

--- a/pkg/i2gw/providers/cilium/force_https.go
+++ b/pkg/i2gw/providers/cilium/force_https.go
@@ -29,7 +29,7 @@ import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
-func forceHTTPSFeature(ingresses []networkingv1.Ingress, ir *intermediate.IR) field.ErrorList {
+func forceHTTPSFeature(ingresses []networkingv1.Ingress, _ map[types.NamespacedName]map[string]int32, ir *intermediate.IR) field.ErrorList {
 	var errs field.ErrorList
 	forceHTTPSAnnotation := ciliumAnnotation("force-https")
 	ruleGroups := common.GetRuleGroups(ingresses)

--- a/pkg/i2gw/providers/cilium/force_https_test.go
+++ b/pkg/i2gw/providers/cilium/force_https_test.go
@@ -320,7 +320,7 @@ func Test_forceHTTPSFeature(t *testing.T) {
 				},
 			}
 
-			errs := forceHTTPSFeature(ingresses, ir)
+			errs := forceHTTPSFeature(ingresses, map[types.NamespacedName]map[string]int32{}, ir)
 
 			if len(errs) != len(tc.expectedError) {
 				t.Errorf("expected %d errors, got %d", len(tc.expectedError), len(errs))

--- a/pkg/i2gw/providers/cilium/resource_reader.go
+++ b/pkg/i2gw/providers/cilium/resource_reader.go
@@ -45,6 +45,12 @@ func (r *resourceReader) readResourcesFromCluster(ctx context.Context) (*storage
 		return nil, err
 	}
 	storage.Ingresses = ingresses
+
+	services, err := common.ReadServicesFromCluster(ctx, r.conf.Client)
+	if err != nil {
+		return nil, err
+	}
+	storage.ServicePorts = common.GroupServicePortsByPortName(services)
 	return storage, nil
 }
 
@@ -57,5 +63,11 @@ func (r *resourceReader) readResourcesFromFile(filename string) (*storage, error
 		return nil, err
 	}
 	storage.Ingresses = ingresses
+
+	services, err := common.ReadServicesFromFile(filename, r.conf.Namespace)
+	if err != nil {
+		return nil, err
+	}
+	storage.ServicePorts = common.GroupServicePortsByPortName(services)
 	return storage, nil
 }

--- a/pkg/i2gw/providers/cilium/storage.go
+++ b/pkg/i2gw/providers/cilium/storage.go
@@ -22,11 +22,13 @@ import (
 )
 
 type storage struct {
-	Ingresses map[types.NamespacedName]*networkingv1.Ingress
+	Ingresses    map[types.NamespacedName]*networkingv1.Ingress
+	ServicePorts map[types.NamespacedName]map[string]int32
 }
 
 func newResourcesStorage() *storage {
 	return &storage{
-		Ingresses: map[types.NamespacedName]*networkingv1.Ingress{},
+		Ingresses:    map[types.NamespacedName]*networkingv1.Ingress{},
+		ServicePorts: map[types.NamespacedName]map[string]int32{},
 	}
 }

--- a/pkg/i2gw/providers/common/resource_reader_test.go
+++ b/pkg/i2gw/providers/common/resource_reader_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	apiv1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,27 +36,35 @@ func Test_ExtractObjectsFromReader(t *testing.T) {
 	ingress2 := ingress(80, "ingress2", "namespace2")
 	ingressNoNamespace := ingress(80, "ingress-no-namespace", "")
 
+	service1 := service(443, "https", "service1", "namespace1")
+	service2 := service(80, "http", "service2", "namespace2")
+	serviceNoNamespace := service(80, "http", "service-no-namespace", "")
+
 	testCases := []struct {
 		name            string
 		filePath        string
 		namespace       string
 		wantIngressList []networkingv1.Ingress
+		wantServiceList []apiv1.Service
 	}{
 		{
 			name:            "Test yaml input file with multiple resources with no namespace flag",
 			filePath:        "testdata/input-file.yaml",
 			namespace:       "",
 			wantIngressList: []networkingv1.Ingress{ingress1, ingress2, ingressNoNamespace},
+			wantServiceList: []apiv1.Service{service1, service2, serviceNoNamespace},
 		}, {
 			name:            "Test json input file with multiple resources with no namespace flag",
 			filePath:        "testdata/input-file.json",
 			namespace:       "",
 			wantIngressList: []networkingv1.Ingress{ingress1, ingress2, ingressNoNamespace},
+			wantServiceList: []apiv1.Service{service1, service2, serviceNoNamespace},
 		}, {
 			name:            "Test yaml input file with multiple resources with namespace1 flag",
 			filePath:        "testdata/input-file.yaml",
 			namespace:       "namespace1",
 			wantIngressList: []networkingv1.Ingress{ingress1},
+			wantServiceList: []apiv1.Service{service1},
 		},
 	}
 
@@ -73,7 +82,13 @@ func Test_ExtractObjectsFromReader(t *testing.T) {
 			if err != nil {
 				t.Errorf("got unexpected error: %v", err)
 			}
+			gotServiceList, err := serviceListFromUnstructured(unstructuredObjects)
+			if err != nil {
+				t.Errorf("got unexpected error: %v", err)
+			}
+
 			compareIngressLists(t, gotIngressList, tc.wantIngressList)
+			compareServiceLists(t, gotServiceList, tc.wantServiceList)
 		})
 	}
 }
@@ -119,6 +134,31 @@ func ingress(port int32, name, namespace string) networkingv1.Ingress {
 	return ing
 }
 
+func service(port int32, portName string, name string, namespace string) apiv1.Service {
+	var objMeta metav1.ObjectMeta
+	if namespace != "" {
+		objMeta = metav1.ObjectMeta{Name: name, ResourceVersion: "999", Namespace: namespace}
+	} else {
+		objMeta = metav1.ObjectMeta{Name: name, ResourceVersion: "999"}
+	}
+
+	service := apiv1.Service{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Service",
+			APIVersion: "v1",
+		},
+		ObjectMeta: objMeta,
+		Spec: apiv1.ServiceSpec{
+			Type: "ClusterIP",
+			Ports: []apiv1.ServicePort{{
+				Name: portName,
+				Port: port,
+			}},
+		},
+	}
+	return service
+}
+
 func ingressListFromUnstructured(unstructuredObjects []*unstructured.Unstructured) (*networkingv1.IngressList, error) {
 	ingressList := &networkingv1.IngressList{}
 	for _, f := range unstructuredObjects {
@@ -134,11 +174,37 @@ func ingressListFromUnstructured(unstructuredObjects []*unstructured.Unstructure
 	}
 	return ingressList, nil
 }
+
+func serviceListFromUnstructured(unstructuredObjects []*unstructured.Unstructured) (*apiv1.ServiceList, error) {
+	serviceList := &apiv1.ServiceList{}
+	for _, f := range unstructuredObjects {
+		if !f.GroupVersionKind().Empty() && f.GroupVersionKind().Kind == "Service" {
+			var service apiv1.Service
+			err := runtime.DefaultUnstructuredConverter.
+				FromUnstructured(f.UnstructuredContent(), &service)
+			if err != nil {
+				return nil, err
+			}
+			serviceList.Items = append(serviceList.Items, service)
+		}
+	}
+	return serviceList, nil
+}
+
 func compareIngressLists(t *testing.T, gotIngressList *networkingv1.IngressList, wantIngressList []networkingv1.Ingress) {
 	for i, got := range gotIngressList.Items {
 		want := wantIngressList[i]
 		if !apiequality.Semantic.DeepEqual(got, want) {
 			t.Errorf("Expected Ingress %d to be %+v\n Got: %+v\n Diff: %s", i, want, got, cmp.Diff(want, got))
+		}
+	}
+}
+
+func compareServiceLists(t *testing.T, gotServiceList *apiv1.ServiceList, wantServiceList []apiv1.Service) {
+	for i, got := range gotServiceList.Items {
+		want := wantServiceList[i]
+		if !apiequality.Semantic.DeepEqual(got, want) {
+			t.Errorf("Expected Service %d to be %+v\n Got: %+v\n Diff: %s", i, want, got, cmp.Diff(want, got))
 		}
 	}
 }

--- a/pkg/i2gw/providers/common/testdata/input-file.json
+++ b/pkg/i2gw/providers/common/testdata/input-file.json
@@ -58,6 +58,59 @@
             }
         },
         {
+            "apiVersion": "v1",
+            "kind": "Service",
+            "metadata": {
+                "name": "service1",
+                "namespace": "namespace1",
+                "resourceVersion": "999"
+            },
+            "spec": {
+                "type": "ClusterIP",
+                "ports": [
+                    {
+                        "name": "https",
+                        "port": 443
+                    }
+                ]
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "Service",
+            "metadata": {
+                "name": "service2",
+                "namespace": "namespace2",
+                "resourceVersion": "999"
+            },
+            "spec": {
+                "type": "ClusterIP",
+                "ports": [
+                    {
+                        "name": "http",
+                        "port": 80
+                    }
+                ]
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "Service",
+            "metadata": {
+                "name": "service-no-namespace",
+                "resourceVersion": "999"
+            },
+            "spec": {
+                "type": "ClusterIP",
+                "ports": [
+                    {
+                        "name": "http",
+                        "port": 80
+                    }
+                ]
+            }
+        },
+        {
             "apiVersion": "networking.k8s.io/v1",
             "kind": "Ingress",
             "metadata": {

--- a/pkg/i2gw/providers/common/testdata/input-file.yaml
+++ b/pkg/i2gw/providers/common/testdata/input-file.yaml
@@ -29,6 +29,41 @@ spec:
     ports: 
     - containerPort: 80
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: service1
+  namespace: namespace1
+  resourceVersion: "999"
+spec:
+  type: ClusterIP
+  ports:
+  - name: https
+    port: 443
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: service2
+  namespace: namespace2
+  resourceVersion: "999"
+spec:
+  type: ClusterIP
+  ports:
+  - name: http
+    port: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: service-no-namespace
+  resourceVersion: "999"
+spec:
+  type: ClusterIP
+  ports:
+  - name: http
+    port: 80
+---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/pkg/i2gw/providers/gce/ir_converter.go
+++ b/pkg/i2gw/providers/gce/ir_converter.go
@@ -74,7 +74,7 @@ func (c *resourcesToIRConverter) convertToIR(storage *storage) (intermediate.IR,
 
 	// Convert plain ingress resources to gateway resources, ignoring all
 	// provider-specific features.
-	ir, errs := common.ToIR(ingressList, c.implementationSpecificOptions)
+	ir, errs := common.ToIR(ingressList, storage.ServicePorts, c.implementationSpecificOptions)
 	if len(errs) > 0 {
 		return intermediate.IR{}, errs
 	}

--- a/pkg/i2gw/providers/gce/storage.go
+++ b/pkg/i2gw/providers/gce/storage.go
@@ -25,8 +25,9 @@ import (
 )
 
 type storage struct {
-	Ingresses map[types.NamespacedName]*networkingv1.Ingress
-	Services  map[types.NamespacedName]*apiv1.Service
+	Ingresses    map[types.NamespacedName]*networkingv1.Ingress
+	Services     map[types.NamespacedName]*apiv1.Service
+	ServicePorts map[types.NamespacedName]map[string]int32
 
 	// BackendConfig is a GKE Ingress extension, and it is associated to an GKE
 	// Ingress through specifying `cloud.google.com/backend-config` or
@@ -44,6 +45,7 @@ func newResourcesStorage() *storage {
 	return &storage{
 		Ingresses:       make(map[types.NamespacedName]*networkingv1.Ingress),
 		Services:        make(map[types.NamespacedName]*apiv1.Service),
+		ServicePorts:    make(map[types.NamespacedName]map[string]int32),
 		BackendConfigs:  make(map[types.NamespacedName]*backendconfigv1.BackendConfig),
 		FrontendConfigs: make(map[types.NamespacedName]*frontendconfigv1beta1.FrontendConfig),
 	}

--- a/pkg/i2gw/providers/ingressnginx/canary_test.go
+++ b/pkg/i2gw/providers/ingressnginx/canary_test.go
@@ -20,9 +20,10 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	corev1 "k8s.io/api/core/v1"
+	apiv1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
@@ -40,7 +41,7 @@ func Test_ingressRuleGroup_calculateBackendRefWeight(t *testing.T) {
 				{
 					path: networkingv1.HTTPIngressPath{
 						Backend: networkingv1.IngressBackend{
-							Resource: &corev1.TypedLocalObjectReference{
+							Resource: &apiv1.TypedLocalObjectReference{
 								Name:     "canary",
 								Kind:     "StorageBucket",
 								APIGroup: ptrTo("vendor.example.com"),
@@ -55,7 +56,7 @@ func Test_ingressRuleGroup_calculateBackendRefWeight(t *testing.T) {
 				{
 					path: networkingv1.HTTPIngressPath{
 						Backend: networkingv1.IngressBackend{
-							Resource: &corev1.TypedLocalObjectReference{
+							Resource: &apiv1.TypedLocalObjectReference{
 								Name:     "prod",
 								Kind:     "StorageBucket",
 								APIGroup: ptrTo("vendor.example.com"),
@@ -75,7 +76,7 @@ func Test_ingressRuleGroup_calculateBackendRefWeight(t *testing.T) {
 				{
 					path: networkingv1.HTTPIngressPath{
 						Backend: networkingv1.IngressBackend{
-							Resource: &corev1.TypedLocalObjectReference{
+							Resource: &apiv1.TypedLocalObjectReference{
 								Name:     "canary",
 								Kind:     "StorageBucket",
 								APIGroup: ptrTo("vendor.example.com"),
@@ -90,7 +91,7 @@ func Test_ingressRuleGroup_calculateBackendRefWeight(t *testing.T) {
 				{
 					path: networkingv1.HTTPIngressPath{
 						Backend: networkingv1.IngressBackend{
-							Resource: &corev1.TypedLocalObjectReference{
+							Resource: &apiv1.TypedLocalObjectReference{
 								Name:     "prod",
 								Kind:     "StorageBucket",
 								APIGroup: ptrTo("vendor.example.com"),
@@ -110,7 +111,7 @@ func Test_ingressRuleGroup_calculateBackendRefWeight(t *testing.T) {
 				{
 					path: networkingv1.HTTPIngressPath{
 						Backend: networkingv1.IngressBackend{
-							Resource: &corev1.TypedLocalObjectReference{
+							Resource: &apiv1.TypedLocalObjectReference{
 								Name:     "canary",
 								Kind:     "StorageBucket",
 								APIGroup: ptrTo("vendor.example.com"),
@@ -125,7 +126,7 @@ func Test_ingressRuleGroup_calculateBackendRefWeight(t *testing.T) {
 				{
 					path: networkingv1.HTTPIngressPath{
 						Backend: networkingv1.IngressBackend{
-							Resource: &corev1.TypedLocalObjectReference{
+							Resource: &apiv1.TypedLocalObjectReference{
 								Name:     "prod",
 								Kind:     "StorageBucket",
 								APIGroup: ptrTo("vendor.example.com"),
@@ -145,7 +146,7 @@ func Test_ingressRuleGroup_calculateBackendRefWeight(t *testing.T) {
 				{
 					path: networkingv1.HTTPIngressPath{
 						Backend: networkingv1.IngressBackend{
-							Resource: &corev1.TypedLocalObjectReference{
+							Resource: &apiv1.TypedLocalObjectReference{
 								Name:     "canary",
 								Kind:     "StorageBucket",
 								APIGroup: ptrTo("vendor.example.com"),
@@ -160,7 +161,7 @@ func Test_ingressRuleGroup_calculateBackendRefWeight(t *testing.T) {
 				{
 					path: networkingv1.HTTPIngressPath{
 						Backend: networkingv1.IngressBackend{
-							Resource: &corev1.TypedLocalObjectReference{
+							Resource: &apiv1.TypedLocalObjectReference{
 								Name:     "prod",
 								Kind:     "StorageBucket",
 								APIGroup: ptrTo("vendor.example.com"),
@@ -180,7 +181,7 @@ func Test_ingressRuleGroup_calculateBackendRefWeight(t *testing.T) {
 				{
 					path: networkingv1.HTTPIngressPath{
 						Backend: networkingv1.IngressBackend{
-							Resource: &corev1.TypedLocalObjectReference{
+							Resource: &apiv1.TypedLocalObjectReference{
 								Name:     "canary",
 								Kind:     "StorageBucket",
 								APIGroup: ptrTo("vendor.example.com"),
@@ -196,7 +197,7 @@ func Test_ingressRuleGroup_calculateBackendRefWeight(t *testing.T) {
 				{
 					path: networkingv1.HTTPIngressPath{
 						Backend: networkingv1.IngressBackend{
-							Resource: &corev1.TypedLocalObjectReference{
+							Resource: &apiv1.TypedLocalObjectReference{
 								Name:     "prod",
 								Kind:     "StorageBucket",
 								APIGroup: ptrTo("vendor.example.com"),
@@ -214,7 +215,7 @@ func Test_ingressRuleGroup_calculateBackendRefWeight(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 
-			actualBackendRefs, errs := calculateBackendRefWeight(tc.paths)
+			actualBackendRefs, errs := calculateBackendRefWeight("example", map[types.NamespacedName]map[string]int32{}, tc.paths)
 			if len(errs) != len(tc.expectedErrors) {
 				t.Fatalf("expected %d errors, got %d", len(tc.expectedErrors), len(errs))
 			}

--- a/pkg/i2gw/providers/ingressnginx/converter.go
+++ b/pkg/i2gw/providers/ingressnginx/converter.go
@@ -44,14 +44,14 @@ func (c *resourcesToIRConverter) convert(storage *storage) (intermediate.IR, fie
 
 	// Convert plain ingress resources to gateway resources, ignoring all
 	// provider-specific features.
-	ir, errs := common.ToIR(ingressList, i2gw.ProviderImplementationSpecificOptions{})
+	ir, errs := common.ToIR(ingressList, storage.ServicePorts, i2gw.ProviderImplementationSpecificOptions{})
 	if len(errs) > 0 {
 		return intermediate.IR{}, errs
 	}
 
 	for _, parseFeatureFunc := range c.featureParsers {
 		// Apply the feature parsing function to the gateway resources, one by one.
-		parseErrs := parseFeatureFunc(ingressList, &ir)
+		parseErrs := parseFeatureFunc(ingressList, storage.ServicePorts, &ir)
 		// Append the parsing errors to the error list.
 		errs = append(errs, parseErrs...)
 	}

--- a/pkg/i2gw/providers/ingressnginx/converter_test.go
+++ b/pkg/i2gw/providers/ingressnginx/converter_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw"
 	"github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw/intermediate"
 	"github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw/providers/common"
-	corev1 "k8s.io/api/core/v1"
+	apiv1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -64,7 +64,7 @@ func Test_ToIR(t *testing.T) {
 											Path:     "/",
 											PathType: &iPrefix,
 											Backend: networkingv1.IngressBackend{
-												Resource: &corev1.TypedLocalObjectReference{
+												Resource: &apiv1.TypedLocalObjectReference{
 													Name:     "production",
 													Kind:     "StorageBucket",
 													APIGroup: ptrTo("vendor.example.com"),
@@ -95,7 +95,7 @@ func Test_ToIR(t *testing.T) {
 											Path:     "/",
 											PathType: &iPrefix,
 											Backend: networkingv1.IngressBackend{
-												Resource: &corev1.TypedLocalObjectReference{
+												Resource: &apiv1.TypedLocalObjectReference{
 													Name:     "canary",
 													Kind:     "StorageBucket",
 													APIGroup: ptrTo("vendor.example.com"),

--- a/pkg/i2gw/providers/ingressnginx/resource_reader.go
+++ b/pkg/i2gw/providers/ingressnginx/resource_reader.go
@@ -44,6 +44,12 @@ func (r *resourceReader) readResourcesFromCluster(ctx context.Context) (*storage
 		return nil, err
 	}
 	storage.Ingresses.FromMap(ingresses)
+
+	services, err := common.ReadServicesFromCluster(ctx, r.conf.Client)
+	if err != nil {
+		return nil, err
+	}
+	storage.ServicePorts = common.GroupServicePortsByPortName(services)
 	return storage, nil
 }
 
@@ -55,5 +61,11 @@ func (r *resourceReader) readResourcesFromFile(filename string) (*storage, error
 		return nil, err
 	}
 	storage.Ingresses.FromMap(ingresses)
+
+	services, err := common.ReadServicesFromFile(filename, r.conf.Namespace)
+	if err != nil {
+		return nil, err
+	}
+	storage.ServicePorts = common.GroupServicePortsByPortName(services)
 	return storage, nil
 }

--- a/pkg/i2gw/providers/ingressnginx/storage.go
+++ b/pkg/i2gw/providers/ingressnginx/storage.go
@@ -28,7 +28,8 @@ type OrderedIngressMap struct {
 	ingressObjects map[types.NamespacedName]*networkingv1.Ingress
 }
 type storage struct {
-	Ingresses OrderedIngressMap
+	Ingresses    OrderedIngressMap
+	ServicePorts map[types.NamespacedName]map[string]int32
 }
 
 func newResourcesStorage() *storage {
@@ -37,6 +38,7 @@ func newResourcesStorage() *storage {
 			ingressNames:   []types.NamespacedName{},
 			ingressObjects: map[types.NamespacedName]*networkingv1.Ingress{},
 		},
+		ServicePorts: map[types.NamespacedName]map[string]int32{},
 	}
 }
 

--- a/pkg/i2gw/providers/kong/converter.go
+++ b/pkg/i2gw/providers/kong/converter.go
@@ -54,7 +54,7 @@ func (c *resourcesToIRConverter) convert(storage *storage) (intermediate.IR, fie
 
 	// Convert plain ingress resources to gateway resources, ignoring all
 	// provider-specific features.
-	ir, errorList := common.ToIR(ingressList, c.implementationSpecificOptions)
+	ir, errorList := common.ToIR(ingressList, storage.ServicePorts, c.implementationSpecificOptions)
 	if len(errorList) > 0 {
 		return intermediate.IR{}, errorList
 	}
@@ -78,7 +78,7 @@ func (c *resourcesToIRConverter) convert(storage *storage) (intermediate.IR, fie
 
 	for _, parseFeatureFunc := range c.featureParsers {
 		// Apply the feature parsing function to the gateway resources, one by one.
-		errs = parseFeatureFunc(ingressList, &ir)
+		errs = parseFeatureFunc(ingressList, storage.ServicePorts, &ir)
 		// Append the parsing errors to the error list.
 		errorList = append(errorList, errs...)
 	}

--- a/pkg/i2gw/providers/kong/header_matching.go
+++ b/pkg/i2gw/providers/kong/header_matching.go
@@ -38,7 +38,7 @@ import (
 //
 // All the values defined for each annotation name, and separated by comma, MUST be ORed.
 // All the annotation names MUST be ANDed, with the respective values.
-func headerMatchingFeature(ingresses []networkingv1.Ingress, ir *intermediate.IR) field.ErrorList {
+func headerMatchingFeature(ingresses []networkingv1.Ingress, _ map[types.NamespacedName]map[string]int32, ir *intermediate.IR) field.ErrorList {
 	ruleGroups := common.GetRuleGroups(ingresses)
 	for _, rg := range ruleGroups {
 		for _, rule := range rg.Rules {

--- a/pkg/i2gw/providers/kong/header_matching_test.go
+++ b/pkg/i2gw/providers/kong/header_matching_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw/providers/common"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
@@ -242,14 +243,14 @@ func TestHeaderMatchingFeature(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			gatewayResources, errs := common.ToIR(tc.ingresses, i2gw.ProviderImplementationSpecificOptions{
+			gatewayResources, errs := common.ToIR(tc.ingresses, map[types.NamespacedName]map[string]int32{}, i2gw.ProviderImplementationSpecificOptions{
 				ToImplementationSpecificHTTPPathTypeMatch: implementationSpecificHTTPPathTypeMatch,
 			})
 			if len(errs) != 0 {
 				t.Errorf("Expected no errors, got %d: %+v", len(errs), errs)
 			}
 
-			errs = headerMatchingFeature(tc.ingresses, &gatewayResources)
+			errs = headerMatchingFeature(tc.ingresses, map[types.NamespacedName]map[string]int32{}, &gatewayResources)
 			if len(errs) != len(tc.expectedErrors) {
 				t.Errorf("Expected %d errors, got %d: %+v", len(tc.expectedErrors), len(errs), errs)
 			} else {

--- a/pkg/i2gw/providers/kong/method_matching.go
+++ b/pkg/i2gw/providers/kong/method_matching.go
@@ -37,7 +37,7 @@ import (
 // konghq.com/methods: "GET,POST"
 //
 // All the values defined and separated by comma, MUST be ORed.
-func methodMatchingFeature(ingresses []networkingv1.Ingress, ir *intermediate.IR) field.ErrorList {
+func methodMatchingFeature(ingresses []networkingv1.Ingress, _ map[types.NamespacedName]map[string]int32, ir *intermediate.IR) field.ErrorList {
 	ruleGroups := common.GetRuleGroups(ingresses)
 	for _, rg := range ruleGroups {
 		for _, rule := range rg.Rules {

--- a/pkg/i2gw/providers/kong/method_matching_test.go
+++ b/pkg/i2gw/providers/kong/method_matching_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw/providers/common"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
@@ -183,14 +184,14 @@ func TestMethodMatchingFeature(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			gatewayResources, errs := common.ToIR(tc.ingresses, i2gw.ProviderImplementationSpecificOptions{
+			gatewayResources, errs := common.ToIR(tc.ingresses, map[types.NamespacedName]map[string]int32{}, i2gw.ProviderImplementationSpecificOptions{
 				ToImplementationSpecificHTTPPathTypeMatch: implementationSpecificHTTPPathTypeMatch,
 			})
 			if len(errs) != 0 {
 				t.Errorf("Expected no errors, got %d: %+v", len(errs), errs)
 			}
 
-			errs = methodMatchingFeature(tc.ingresses, &gatewayResources)
+			errs = methodMatchingFeature(tc.ingresses, map[types.NamespacedName]map[string]int32{}, &gatewayResources)
 			if len(errs) != len(tc.expectedErrors) {
 				t.Errorf("Expected %d errors, got %d: %+v", len(tc.expectedErrors), len(errs), errs)
 			} else {

--- a/pkg/i2gw/providers/kong/plugins.go
+++ b/pkg/i2gw/providers/kong/plugins.go
@@ -36,7 +36,7 @@ import (
 // a comma-separated list.
 //
 // Example: konghq.com/plugins: "plugin1,plugin2"
-func pluginsFeature(ingresses []networkingv1.Ingress, ir *intermediate.IR) field.ErrorList {
+func pluginsFeature(ingresses []networkingv1.Ingress, _ map[types.NamespacedName]map[string]int32, ir *intermediate.IR) field.ErrorList {
 	ruleGroups := common.GetRuleGroups(ingresses)
 	for _, rg := range ruleGroups {
 		for _, rule := range rg.Rules {

--- a/pkg/i2gw/providers/kong/resource_reader.go
+++ b/pkg/i2gw/providers/kong/resource_reader.go
@@ -62,6 +62,12 @@ func (r *resourceReader) readResourcesFromCluster(ctx context.Context) (*storage
 	}
 	storage.TCPIngresses = tcpIngresses
 
+	services, err := common.ReadServicesFromCluster(ctx, r.conf.Client)
+	if err != nil {
+		return nil, err
+	}
+	storage.ServicePorts = common.GroupServicePortsByPortName(services)
+
 	return storage, nil
 }
 
@@ -79,6 +85,12 @@ func (r *resourceReader) readResourcesFromFile(filename string) (*storage, error
 		return nil, fmt.Errorf("failed to read TCPIngresses: %w", err)
 	}
 	storage.TCPIngresses = tcpIngresses
+
+	services, err := common.ReadServicesFromFile(filename, r.conf.Namespace)
+	if err != nil {
+		return nil, err
+	}
+	storage.ServicePorts = common.GroupServicePortsByPortName(services)
 
 	return storage, nil
 }

--- a/pkg/i2gw/providers/kong/storage.go
+++ b/pkg/i2gw/providers/kong/storage.go
@@ -25,11 +25,13 @@ import (
 type storage struct {
 	Ingresses    map[types.NamespacedName]*networkingv1.Ingress
 	TCPIngresses []kongv1beta1.TCPIngress
+	ServicePorts map[types.NamespacedName]map[string]int32
 }
 
 func newResourceStorage() *storage {
 	return &storage{
 		Ingresses:    map[types.NamespacedName]*networkingv1.Ingress{},
 		TCPIngresses: []kongv1beta1.TCPIngress{},
+		ServicePorts: map[types.NamespacedName]map[string]int32{},
 	}
 }


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/ingress2gateway/blob/main/CONTRIBUTING.md). -->

<!-- The release notes and the kind will be used to generate the Changelog for the release. To make sure your contribution is recognized, please label this pull request according to what type of issue you are addressing and add the release notes when necessary (see ../CONTRIBUTING.md) -->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

**What this PR does / why we need it**:

Support converting ingress rules with named ports.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #209

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->

The proposed change includes the following steps:

1. Read service definitions at the same time as we read ingresses. (resource readers)
2. Construct a mapping from port names to port numbers for each service.
3. Use this mapping to resolve port name references into port numbers.

```release-note
Add support for named ports
```
