### PR TITLE
Add server-alias support for ingress-nginx provider

### DIFF
--- a/pkg/i2gw/providers/ingressnginx/README.md
+++ b/pkg/i2gw/providers/ingressnginx/README.md
@@ -11,6 +11,6 @@ Current supported annotations:
 - `nginx.ingress.kubernetes.io/canary-by-header-pattern`: If specified, this is the pattern to match against for the HTTPHeaderMatch, which will be of type HeaderMatchRegularExpression.
 - `nginx.ingress.kubernetes.io/canary-weight`: If specified and non-zero, this value will be applied as the weight of the backends for the routes generated from this Ingress resource.
 - `nginx.ingress.kubernetes.io/canary-weight-total`: If specified, this value will be used as the total weight for canary deployments.
-- `nginx.ingress.kubernetes.io/server-alias`: If specified, this value will be added as additional hostnames to the Gateway listeners and HTTPRoutes. Supports comma-separated values for multiple aliases.
+- `nginx.ingress.kubernetes.io/server-alias`: If specified, this value will be added as additional hostnames to the HTTPRoutes. Supports comma-separated values for multiple aliases.
 
 If you are reliant on any annotations not listed above, please open an issue. In the meantime you'll need to manually find a Gateway API equivalent.

--- a/pkg/i2gw/providers/ingressnginx/README.md
+++ b/pkg/i2gw/providers/ingressnginx/README.md
@@ -11,6 +11,6 @@ Current supported annotations:
 - `nginx.ingress.kubernetes.io/canary-by-header-pattern`: If specified, this is the pattern to match against for the HTTPHeaderMatch, which will be of type HeaderMatchRegularExpression.
 - `nginx.ingress.kubernetes.io/canary-weight`: If specified and non-zero, this value will be applied as the weight of the backends for the routes generated from this Ingress resource.
 - `nginx.ingress.kubernetes.io/canary-weight-total`: If specified, this value will be used as the total weight for canary deployments.
-- `nginx.ingress.kubernetes.io/server-alias`: If specified, this value will be added as additional hostnames to the HTTPRoutes. Supports comma-separated values for multiple aliases.
+- `nginx.ingress.kubernetes.io/server-alias`: If specified, this value will be added as additional hostnames to the HTTPRoutes. Supports comma-separated values for multiple aliases. Note: ingress2gateway will create an empty Gateway Listener, and will add all the values in server-alias annotation to the generated HTTPRoute.spec.hostnames
 
 If you are reliant on any annotations not listed above, please open an issue. In the meantime you'll need to manually find a Gateway API equivalent.

--- a/pkg/i2gw/providers/ingressnginx/README.md
+++ b/pkg/i2gw/providers/ingressnginx/README.md
@@ -10,6 +10,7 @@ Current supported annotations:
 - `nginx.ingress.kubernetes.io/canary-by-header-value`: If specified, the value of this annotation is the header value to perform an HeaderMatchExact match on in the generated HTTPHeaderMatch.
 - `nginx.ingress.kubernetes.io/canary-by-header-pattern`: If specified, this is the pattern to match against for the HTTPHeaderMatch, which will be of type HeaderMatchRegularExpression.
 - `nginx.ingress.kubernetes.io/canary-weight`: If specified and non-zero, this value will be applied as the weight of the backends for the routes generated from this Ingress resource.
-`nginx.ingress.kubernetes.io/canary-weight-total`
+- `nginx.ingress.kubernetes.io/canary-weight-total`: If specified, this value will be used as the total weight for canary deployments.
+- `nginx.ingress.kubernetes.io/server-alias`: If specified, this value will be added as additional hostnames to the Gateway listeners and HTTPRoutes. Supports comma-separated values for multiple aliases.
 
 If you are reliant on any annotations not listed above, please open an issue. In the meantime you'll need to manually find a Gateway API equivalent.

--- a/pkg/i2gw/providers/ingressnginx/canary.go
+++ b/pkg/i2gw/providers/ingressnginx/canary.go
@@ -21,7 +21,6 @@ import (
 	"strconv"
 
 	"github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw/intermediate"
-	"github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw/notifications"
 	"github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw/providers/common"
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -123,7 +122,7 @@ func patchHTTPRouteWithBackendRefs(httpRoute *gatewayv1.HTTPRoute, backendRefs [
 		}
 	}
 	if ruleExists {
-		notify(notifications.InfoNotification, fmt.Sprintf("parsed canary annotations of ingress and patched %v fields", field.NewPath("httproute", "spec", "rules").Key("").Child("backendRefs")), httpRoute)
+		notify(fmt.Sprintf("parsed canary annotations of ingress and patched %v fields", field.NewPath("httproute", "spec", "rules").Key("").Child("backendRefs")), httpRoute)
 	}
 }
 

--- a/pkg/i2gw/providers/ingressnginx/converter.go
+++ b/pkg/i2gw/providers/ingressnginx/converter.go
@@ -33,6 +33,7 @@ func newResourcesToIRConverter() *resourcesToIRConverter {
 	return &resourcesToIRConverter{
 		featureParsers: []i2gw.FeatureParser{
 			canaryFeature,
+			serverAliasFeature,
 		},
 	}
 }

--- a/pkg/i2gw/providers/ingressnginx/notification.go
+++ b/pkg/i2gw/providers/ingressnginx/notification.go
@@ -21,7 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func notify(mType notifications.MessageType, message string, callingObject ...client.Object) { //nolint:unparam
-	newNotification := notifications.NewNotification(mType, message, callingObject...)
+func notify(message string, callingObject ...client.Object) {
+	newNotification := notifications.NewNotification(notifications.InfoNotification, message, callingObject...)
 	notifications.NotificationAggr.DispatchNotification(newNotification, string(Name))
 }

--- a/pkg/i2gw/providers/ingressnginx/notification.go
+++ b/pkg/i2gw/providers/ingressnginx/notification.go
@@ -21,7 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func notify(mType notifications.MessageType, message string, callingObject ...client.Object) {
+func notify(mType notifications.MessageType, message string, callingObject ...client.Object) { //nolint:unparam
 	newNotification := notifications.NewNotification(mType, message, callingObject...)
 	notifications.NotificationAggr.DispatchNotification(newNotification, string(Name))
 }

--- a/pkg/i2gw/providers/ingressnginx/server_alias.go
+++ b/pkg/i2gw/providers/ingressnginx/server_alias.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 
 	"github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw/intermediate"
-	"github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw/notifications"
 	"github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw/providers/common"
 
 	networkingv1 "k8s.io/api/networking/v1"
@@ -63,8 +62,9 @@ func serverAliasFeature(ingresses []networkingv1.Ingress, _ map[types.Namespaced
 				}
 			}
 
-			notify(notifications.InfoNotification,
-				fmt.Sprintf("parsed server-alias annotation with %d aliases: %s", len(aliases), strings.Join(aliases, ", ")), &ingress)
+			notify(
+				fmt.Sprintf("parsed server-alias annotation with %d aliases: %s", len(aliases), strings.Join(aliases, ", ")), &ingress,
+			)
 		}
 	}
 
@@ -81,9 +81,10 @@ func serverAliasFeature(ingresses []networkingv1.Ingress, _ map[types.Namespaced
 
 					if !exists {
 						routeContext.Spec.Hostnames = append(routeContext.Spec.Hostnames, hostname)
-						notify(notifications.InfoNotification,
+						notify(
 							fmt.Sprintf("added server alias hostname \"%s\" to HTTPRoute \"%s\" for Gateway \"%s\"", alias, routeContext.Name, gatewayKey.Name),
-							&routeContext.HTTPRoute)
+							&routeContext.HTTPRoute,
+						)
 
 						// Update the route context in the IR
 						ir.HTTPRoutes[routeKey] = routeContext

--- a/pkg/i2gw/providers/ingressnginx/server_alias.go
+++ b/pkg/i2gw/providers/ingressnginx/server_alias.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ingressnginx
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw/intermediate"
+	"github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw/notifications"
+	"github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw/providers/common"
+
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+// serverAliasFeature processes the server-alias annotation for ingress-nginx.
+// https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#server-alias
+func serverAliasFeature(ingresses []networkingv1.Ingress, _ map[types.NamespacedName]map[string]int32, ir *intermediate.IR) field.ErrorList {
+	var errs field.ErrorList
+
+	// Keep track of server aliases per gateway
+	serverAliasesByGateway := make(map[types.NamespacedName][]string)
+
+	for _, ingress := range ingresses {
+		if serverAlias, ok := ingress.Annotations["nginx.ingress.kubernetes.io/server-alias"]; ok && serverAlias != "" {
+			aliases := strings.Split(serverAlias, ",")
+
+			// Determine which gateway this ingress belongs to
+			// For ingress-nginx, the gateway name is typically the ingress class name
+			ingressClass := common.GetIngressClass(ingress)
+			if ingressClass == "" {
+				ingressClass = "nginx" // default for ingress-nginx
+			}
+
+			gatewayKey := types.NamespacedName{Namespace: ingress.Namespace, Name: ingressClass}
+
+			// Collect all unique aliases for this gateway
+			existingAliases := serverAliasesByGateway[gatewayKey]
+			for _, alias := range aliases {
+				alias = strings.TrimSpace(alias)
+				// Check if alias already exists for this gateway
+				exists := slices.Contains(existingAliases, alias)
+				if !exists {
+					serverAliasesByGateway[gatewayKey] = append(serverAliasesByGateway[gatewayKey], alias)
+				}
+			}
+
+			notify(notifications.InfoNotification,
+				fmt.Sprintf("parsed server-alias annotation with %d aliases: %s", len(aliases), strings.Join(aliases, ", ")), &ingress)
+		}
+	}
+
+	// Process each gateway that has server aliases
+	for gatewayKey, aliases := range serverAliasesByGateway {
+		gatewayContext, exists := ir.Gateways[gatewayKey]
+		if !exists {
+			continue // Skip if the gateway doesn't exist in the IR
+		}
+
+		// Find an existing listener to base the new ones on (use the first HTTP/HTTPS listener)
+		var baseListener *gatewayv1.Listener
+		for i, listener := range gatewayContext.Spec.Listeners {
+			if listener.Protocol == gatewayv1.HTTPProtocolType || listener.Protocol == gatewayv1.HTTPSProtocolType {
+				baseListener = &gatewayContext.Spec.Listeners[i]
+				break
+			}
+		}
+
+		if baseListener != nil {
+			// Create additional listeners for each server alias
+			for _, alias := range aliases {
+				hostname := gatewayv1.Hostname(alias)
+
+				// Create a new listener based on the existing one but with the alias hostname
+				aliasListener := gatewayv1.Listener{
+					Name:     gatewayv1.SectionName(common.NameFromHost(alias)),
+					Hostname: &hostname,
+					Protocol: baseListener.Protocol,
+					Port:     baseListener.Port,
+					TLS:      baseListener.TLS,
+				}
+
+				// Add the new listener to the gateway
+				gatewayContext.Spec.Listeners = append(gatewayContext.Spec.Listeners, aliasListener)
+
+				notify(notifications.InfoNotification,
+					fmt.Sprintf("added server alias listener for hostname: %s", alias),
+					&gatewayContext.Gateway)
+			}
+
+			// Update the gateway context in the IR
+			ir.Gateways[gatewayKey] = gatewayContext
+		}
+
+		// Also update HTTPRoutes to include the server aliases as additional hostnames
+		for routeKey, routeContext := range ir.HTTPRoutes {
+			if routeKey.Namespace == gatewayKey.Namespace {
+				// Add server aliases as additional hostnames to the HTTPRoute
+				for _, alias := range aliases {
+					hostname := gatewayv1.Hostname(alias)
+					// Check if this hostname already exists
+					exists := slices.Contains(routeContext.Spec.Hostnames, hostname)
+
+					if !exists {
+						routeContext.Spec.Hostnames = append(routeContext.Spec.Hostnames, hostname)
+						notify(notifications.InfoNotification,
+							fmt.Sprintf("added server alias hostname to HTTPRoute: %s", alias),
+							&routeContext.HTTPRoute)
+
+						// Update the route context in the IR
+						ir.HTTPRoutes[routeKey] = routeContext
+					}
+				}
+			}
+		}
+	}
+	return errs
+}

--- a/pkg/i2gw/providers/ingressnginx/server_alias.go
+++ b/pkg/i2gw/providers/ingressnginx/server_alias.go
@@ -82,7 +82,7 @@ func serverAliasFeature(ingresses []networkingv1.Ingress, _ map[types.Namespaced
 					if !exists {
 						routeContext.Spec.Hostnames = append(routeContext.Spec.Hostnames, hostname)
 						notify(notifications.InfoNotification,
-							fmt.Sprintf("added server alias hostname to HTTPRoute: %s", alias),
+							fmt.Sprintf("added server alias hostname \"%s\" to HTTPRoute \"%s\" for Gateway \"%s\"", alias, routeContext.Name, gatewayKey.Name),
 							&routeContext.HTTPRoute)
 
 						// Update the route context in the IR

--- a/pkg/i2gw/providers/ingressnginx/server_alias_test.go
+++ b/pkg/i2gw/providers/ingressnginx/server_alias_test.go
@@ -123,18 +123,6 @@ func TestServerAliasFeature(t *testing.T) {
 										Port:     80,
 										Hostname: ptrTo(gatewayv1.Hostname("example.com")),
 									},
-									{
-										Name:     "api-example-com",
-										Protocol: gatewayv1.HTTPProtocolType,
-										Port:     80,
-										Hostname: ptrTo(gatewayv1.Hostname("api.example.com")),
-									},
-									{
-										Name:     "cdn-example-com",
-										Protocol: gatewayv1.HTTPProtocolType,
-										Port:     80,
-										Hostname: ptrTo(gatewayv1.Hostname("cdn.example.com")),
-									},
 								},
 							},
 						},

--- a/pkg/i2gw/providers/ingressnginx/server_alias_test.go
+++ b/pkg/i2gw/providers/ingressnginx/server_alias_test.go
@@ -1,0 +1,212 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ingressnginx
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw/intermediate"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func TestServerAliasFeature(t *testing.T) {
+	testCases := []struct {
+		name           string
+		ingresses      []networkingv1.Ingress
+		initialIR      intermediate.IR
+		expectedIR     intermediate.IR
+		expectedErrors int
+	}{
+		{
+			name: "ingress with server alias annotation",
+			ingresses: []networkingv1.Ingress{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-ingress",
+						Namespace: "default",
+						Annotations: map[string]string{
+							"nginx.ingress.kubernetes.io/server-alias": "api.example.com,cdn.example.com",
+						},
+					},
+					Spec: networkingv1.IngressSpec{
+						IngressClassName: ptrTo("test-gateway"),
+						Rules: []networkingv1.IngressRule{
+							{
+								Host: "example.com",
+								IngressRuleValue: networkingv1.IngressRuleValue{
+									HTTP: &networkingv1.HTTPIngressRuleValue{
+										Paths: []networkingv1.HTTPIngressPath{
+											{
+												Path:     "/",
+												PathType: ptrTo(networkingv1.PathTypePrefix),
+												Backend: networkingv1.IngressBackend{
+													Service: &networkingv1.IngressServiceBackend{
+														Name: "test-service",
+														Port: networkingv1.ServiceBackendPort{Number: 80},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			initialIR: intermediate.IR{
+				Gateways: map[types.NamespacedName]intermediate.GatewayContext{
+					{Name: "test-gateway", Namespace: "default"}: {
+						Gateway: gatewayv1.Gateway{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "test-gateway",
+								Namespace: "default",
+							},
+							Spec: gatewayv1.GatewaySpec{
+								Listeners: []gatewayv1.Listener{
+									{
+										Name:     "http",
+										Protocol: gatewayv1.HTTPProtocolType,
+										Port:     80,
+										Hostname: ptrTo(gatewayv1.Hostname("example.com")),
+									},
+								},
+							},
+						},
+					},
+				},
+				HTTPRoutes: map[types.NamespacedName]intermediate.HTTPRouteContext{
+					{Name: "test-route", Namespace: "default"}: {
+						HTTPRoute: gatewayv1.HTTPRoute{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "test-route",
+								Namespace: "default",
+							},
+							Spec: gatewayv1.HTTPRouteSpec{
+								Hostnames: []gatewayv1.Hostname{"example.com"},
+							},
+						},
+					},
+				},
+			},
+			expectedIR: intermediate.IR{
+				Gateways: map[types.NamespacedName]intermediate.GatewayContext{
+					{Name: "test-gateway", Namespace: "default"}: {
+						Gateway: gatewayv1.Gateway{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "test-gateway",
+								Namespace: "default",
+							},
+							Spec: gatewayv1.GatewaySpec{
+								Listeners: []gatewayv1.Listener{
+									{
+										Name:     "http",
+										Protocol: gatewayv1.HTTPProtocolType,
+										Port:     80,
+										Hostname: ptrTo(gatewayv1.Hostname("example.com")),
+									},
+									{
+										Name:     "api-example-com",
+										Protocol: gatewayv1.HTTPProtocolType,
+										Port:     80,
+										Hostname: ptrTo(gatewayv1.Hostname("api.example.com")),
+									},
+									{
+										Name:     "cdn-example-com",
+										Protocol: gatewayv1.HTTPProtocolType,
+										Port:     80,
+										Hostname: ptrTo(gatewayv1.Hostname("cdn.example.com")),
+									},
+								},
+							},
+						},
+					},
+				},
+				HTTPRoutes: map[types.NamespacedName]intermediate.HTTPRouteContext{
+					{Name: "test-route", Namespace: "default"}: {
+						HTTPRoute: gatewayv1.HTTPRoute{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "test-route",
+								Namespace: "default",
+							},
+							Spec: gatewayv1.HTTPRouteSpec{
+								Hostnames: []gatewayv1.Hostname{
+									"example.com",
+									"api.example.com",
+									"cdn.example.com",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedErrors: 0,
+		},
+		{
+			name: "ingress without server alias annotation",
+			ingresses: []networkingv1.Ingress{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-ingress",
+						Namespace: "default",
+					},
+					Spec: networkingv1.IngressSpec{
+						Rules: []networkingv1.IngressRule{
+							{
+								Host: "example.com",
+							},
+						},
+					},
+				},
+			},
+			initialIR: intermediate.IR{
+				Gateways:   map[types.NamespacedName]intermediate.GatewayContext{},
+				HTTPRoutes: map[types.NamespacedName]intermediate.HTTPRouteContext{},
+			},
+			expectedIR: intermediate.IR{
+				Gateways:   map[types.NamespacedName]intermediate.GatewayContext{},
+				HTTPRoutes: map[types.NamespacedName]intermediate.HTTPRouteContext{},
+			},
+			expectedErrors: 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ir := tc.initialIR
+			errs := serverAliasFeature(tc.ingresses, nil, &ir)
+
+			if len(errs) != tc.expectedErrors {
+				t.Fatalf("Expected %d errors, got %d: %v", tc.expectedErrors, len(errs), errs)
+			}
+
+			// Compare gateways
+			if diff := cmp.Diff(tc.expectedIR.Gateways, ir.Gateways); diff != "" {
+				t.Fatalf("Gateways mismatch (-want +got):\n%s", diff)
+			}
+
+			// Compare HTTPRoutes
+			if diff := cmp.Diff(tc.expectedIR.HTTPRoutes, ir.HTTPRoutes); diff != "" {
+				t.Fatalf("HTTPRoutes mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

Adds support for the `nginx.ingress.kubernetes.io/server-alias` ingress-nginx annotation 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Add support for ingress-nginx server-alias annotation
```
