### PR TITLE
Idea/concept: Add source ingress annotation to httproute

### DIFF
--- a/pkg/i2gw/providers/common/converter.go
+++ b/pkg/i2gw/providers/common/converter.go
@@ -123,7 +123,8 @@ type ingressRuleGroup struct {
 }
 
 type ingressRule struct {
-	rule networkingv1.IngressRule
+	rule          networkingv1.IngressRule
+	sourceIngress types.NamespacedName
 }
 
 type ingressDefaultBackend struct {
@@ -170,7 +171,7 @@ func (a *ingressAggregator) addIngressRule(namespace, name, ingressClass string,
 	if len(iSpec.TLS) > 0 {
 		rg.tls = append(rg.tls, iSpec.TLS...)
 	}
-	rg.rules = append(rg.rules, ingressRule{rule: rule})
+	rg.rules = append(rg.rules, ingressRule{rule: rule, sourceIngress: types.NamespacedName{Namespace: namespace, Name: name}})
 }
 
 func (a *ingressAggregator) toHTTPRoutesAndGateways(options i2gw.ProviderImplementationSpecificOptions) ([]gatewayv1.HTTPRoute, []gatewayv1.Gateway, field.ErrorList) {

--- a/pkg/i2gw/providers/common/utils.go
+++ b/pkg/i2gw/providers/common/utils.go
@@ -154,7 +154,7 @@ func groupIngressPathsByMatchKey(rules []ingressRule) orderedIngressPathsByMatch
 
 	for i, ir := range rules {
 		for j, path := range ir.rule.HTTP.Paths {
-			ip := ingressPath{ruleIdx: i, pathIdx: j, ruleType: "http", path: path}
+			ip := ingressPath{ruleIdx: i, pathIdx: j, ruleType: "http", path: path, sourceIngress: ir.sourceIngress}
 			pmKey := getPathMatchKey(ip)
 			if _, ok := ingressPathsByMatchKey.data[pmKey]; !ok {
 				ingressPathsByMatchKey.keys = append(ingressPathsByMatchKey.keys, pmKey)

--- a/pkg/i2gw/providers/common/utils_test.go
+++ b/pkg/i2gw/providers/common/utils_test.go
@@ -46,7 +46,7 @@ func TestGroupIngressPathsByMatchKey(t *testing.T) {
 			name: "1 rule with 1 match",
 			rules: []ingressRule{
 				{
-					networkingv1.IngressRule{
+					rule: networkingv1.IngressRule{
 						IngressRuleValue: networkingv1.IngressRuleValue{
 							HTTP: &networkingv1.HTTPIngressRuleValue{
 								Paths: []networkingv1.HTTPIngressPath{
@@ -66,6 +66,7 @@ func TestGroupIngressPathsByMatchKey(t *testing.T) {
 							},
 						},
 					},
+					sourceIngress: types.NamespacedName{Namespace: "test", Name: "test"},
 				},
 			},
 			expected: orderedIngressPathsByMatchKey{
@@ -99,7 +100,7 @@ func TestGroupIngressPathsByMatchKey(t *testing.T) {
 			name: "1 rule, multiple matches, different path",
 			rules: []ingressRule{
 				{
-					networkingv1.IngressRule{
+					rule: networkingv1.IngressRule{
 						IngressRuleValue: networkingv1.IngressRuleValue{
 							HTTP: &networkingv1.HTTPIngressRuleValue{
 								Paths: []networkingv1.HTTPIngressPath{
@@ -131,6 +132,7 @@ func TestGroupIngressPathsByMatchKey(t *testing.T) {
 							},
 						},
 					},
+					sourceIngress: types.NamespacedName{Namespace: "test", Name: "test"},
 				},
 			},
 			expected: orderedIngressPathsByMatchKey{
@@ -184,7 +186,7 @@ func TestGroupIngressPathsByMatchKey(t *testing.T) {
 			name: "multiple rules with single matches, same path",
 			rules: []ingressRule{
 				{
-					networkingv1.IngressRule{
+					rule: networkingv1.IngressRule{
 						IngressRuleValue: networkingv1.IngressRuleValue{
 							HTTP: &networkingv1.HTTPIngressRuleValue{
 								Paths: []networkingv1.HTTPIngressPath{
@@ -204,9 +206,10 @@ func TestGroupIngressPathsByMatchKey(t *testing.T) {
 							},
 						},
 					},
+					sourceIngress: types.NamespacedName{Namespace: "test", Name: "test"},
 				},
 				{
-					networkingv1.IngressRule{
+					rule: networkingv1.IngressRule{
 						IngressRuleValue: networkingv1.IngressRuleValue{
 							HTTP: &networkingv1.HTTPIngressRuleValue{
 								Paths: []networkingv1.HTTPIngressPath{
@@ -226,6 +229,7 @@ func TestGroupIngressPathsByMatchKey(t *testing.T) {
 							},
 						},
 					},
+					sourceIngress: types.NamespacedName{Namespace: "test", Name: "test"},
 				},
 			},
 			expected: orderedIngressPathsByMatchKey{
@@ -276,7 +280,7 @@ func TestGroupIngressPathsByMatchKey(t *testing.T) {
 			name: "multiple rules with single matches, different path",
 			rules: []ingressRule{
 				{
-					networkingv1.IngressRule{
+					rule: networkingv1.IngressRule{
 						IngressRuleValue: networkingv1.IngressRuleValue{
 							HTTP: &networkingv1.HTTPIngressRuleValue{
 								Paths: []networkingv1.HTTPIngressPath{
@@ -296,9 +300,10 @@ func TestGroupIngressPathsByMatchKey(t *testing.T) {
 							},
 						},
 					},
+					sourceIngress: types.NamespacedName{Namespace: "test", Name: "test"},
 				},
 				{
-					networkingv1.IngressRule{
+					rule: networkingv1.IngressRule{
 						IngressRuleValue: networkingv1.IngressRuleValue{
 							HTTP: &networkingv1.HTTPIngressRuleValue{
 								Paths: []networkingv1.HTTPIngressPath{
@@ -318,6 +323,7 @@ func TestGroupIngressPathsByMatchKey(t *testing.T) {
 							},
 						},
 					},
+					sourceIngress: types.NamespacedName{Namespace: "test", Name: "test"},
 				},
 			},
 			expected: orderedIngressPathsByMatchKey{
@@ -371,7 +377,7 @@ func TestGroupIngressPathsByMatchKey(t *testing.T) {
 			name: "multiple rules with multiple matches, mixed paths",
 			rules: []ingressRule{
 				{
-					networkingv1.IngressRule{
+					rule: networkingv1.IngressRule{
 						IngressRuleValue: networkingv1.IngressRuleValue{
 							HTTP: &networkingv1.HTTPIngressRuleValue{
 								Paths: []networkingv1.HTTPIngressPath{
@@ -403,9 +409,10 @@ func TestGroupIngressPathsByMatchKey(t *testing.T) {
 							},
 						},
 					},
+					sourceIngress: types.NamespacedName{Namespace: "test", Name: "test"},
 				},
 				{
-					networkingv1.IngressRule{
+					rule: networkingv1.IngressRule{
 						IngressRuleValue: networkingv1.IngressRuleValue{
 							HTTP: &networkingv1.HTTPIngressRuleValue{
 								Paths: []networkingv1.HTTPIngressPath{
@@ -437,6 +444,7 @@ func TestGroupIngressPathsByMatchKey(t *testing.T) {
 							},
 						},
 					},
+					sourceIngress: types.NamespacedName{Namespace: "test", Name: "test"},
 				},
 			},
 			expected: orderedIngressPathsByMatchKey{

--- a/pkg/i2gw/providers/common/utils_test.go
+++ b/pkg/i2gw/providers/common/utils_test.go
@@ -91,6 +91,7 @@ func TestGroupIngressPathsByMatchKey(t *testing.T) {
 									},
 								},
 							},
+							sourceIngress: types.NamespacedName{Namespace: "test", Name: "test"},
 						},
 					},
 				},
@@ -158,6 +159,7 @@ func TestGroupIngressPathsByMatchKey(t *testing.T) {
 									},
 								},
 							},
+							sourceIngress: types.NamespacedName{Namespace: "test", Name: "test"},
 						},
 					},
 					"Prefix//test2": {
@@ -177,6 +179,7 @@ func TestGroupIngressPathsByMatchKey(t *testing.T) {
 									},
 								},
 							},
+							sourceIngress: types.NamespacedName{Namespace: "test", Name: "test"},
 						},
 					},
 				},
@@ -254,6 +257,7 @@ func TestGroupIngressPathsByMatchKey(t *testing.T) {
 									},
 								},
 							},
+							sourceIngress: types.NamespacedName{Namespace: "test", Name: "test"},
 						},
 						{
 							ruleIdx:  1,
@@ -271,6 +275,7 @@ func TestGroupIngressPathsByMatchKey(t *testing.T) {
 									},
 								},
 							},
+							sourceIngress: types.NamespacedName{Namespace: "test", Name: "test"},
 						},
 					},
 				},
@@ -349,6 +354,7 @@ func TestGroupIngressPathsByMatchKey(t *testing.T) {
 									},
 								},
 							},
+							sourceIngress: types.NamespacedName{Namespace: "test", Name: "test"},
 						},
 					},
 					"Prefix//test2": {
@@ -368,6 +374,7 @@ func TestGroupIngressPathsByMatchKey(t *testing.T) {
 									},
 								},
 							},
+							sourceIngress: types.NamespacedName{Namespace: "test", Name: "test"},
 						},
 					},
 				},
@@ -471,6 +478,7 @@ func TestGroupIngressPathsByMatchKey(t *testing.T) {
 									},
 								},
 							},
+							sourceIngress: types.NamespacedName{Namespace: "test", Name: "test"},
 						},
 						{
 							ruleIdx:  1,
@@ -488,6 +496,7 @@ func TestGroupIngressPathsByMatchKey(t *testing.T) {
 									},
 								},
 							},
+							sourceIngress: types.NamespacedName{Namespace: "test", Name: "test"},
 						},
 					},
 					"Prefix//test12": {
@@ -507,6 +516,7 @@ func TestGroupIngressPathsByMatchKey(t *testing.T) {
 									},
 								},
 							},
+							sourceIngress: types.NamespacedName{Namespace: "test", Name: "test"},
 						},
 					},
 					"Prefix//test21": {
@@ -526,6 +536,7 @@ func TestGroupIngressPathsByMatchKey(t *testing.T) {
 									},
 								},
 							},
+							sourceIngress: types.NamespacedName{Namespace: "test", Name: "test"},
 						},
 					},
 				},


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/ingress2gateway/blob/main/CONTRIBUTING.md). -->

<!-- The release notes and the kind will be used to generate the Changelog for the release. To make sure your contribution is recognized, please label this pull request according to what type of issue you are addressing and add the release notes when necessary (see ../CONTRIBUTING.md) -->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

This PR adds an annotation to each httproute, allowing Ingress2Gateway to track which Ingress resource contributed each HTTPRouteRule. This is necessary because when multiple Ingresses are merged into a single HTTPRoute (sharing host, namespace, and class), the origin of individual rules is currently lost.

Tracking the source Ingress enables providers to correctly scope annotations and features that are defined per-Ingress, rather than applying them incorrectly to all rules in a merged HTTPRoute.

This change does not affect merging behavior or output structure, but adds metadata that downstream provider implementations can optionally use.

**Which issue(s) this PR fixes**:
Fixes #229 

**Does this PR introduce a user-facing change?**:
```release-note
None
````

