### PR TITLE
Add parameter to ingress-nginx provider to select ingress class

### DIFF
--- a/pkg/i2gw/providers/ingressnginx/README.md
+++ b/pkg/i2gw/providers/ingressnginx/README.md
@@ -2,6 +2,10 @@
 
 The project supports translating ingress-nginx specific annotations.
 
+**Ingress class name**
+
+To specify the name of the Ingress class to select, use `--ingress-nginx-ingress-class=ingress-nginx` (default to 'nginx').
+
 Current supported annotations:
 
 - `nginx.ingress.kubernetes.io/canary`: If set to true will enable weighting backends.

--- a/pkg/i2gw/providers/ingressnginx/ingressnginx.go
+++ b/pkg/i2gw/providers/ingressnginx/ingressnginx.go
@@ -29,9 +29,15 @@ import (
 // The Name of the provider.
 const Name = "ingress-nginx"
 const NginxIngressClass = "nginx"
+const NginxIngressClassFlag = "ingress-class"
 
 func init() {
 	i2gw.ProviderConstructorByName[Name] = NewProvider
+	i2gw.RegisterProviderSpecificFlag(Name, i2gw.ProviderSpecificFlag{
+		Name:         "ingress-class",
+		Description:  "The name of the ingress class to select. Defaults to 'nginx'",
+		DefaultValue: NginxIngressClass,
+	})
 }
 
 // Provider implements the i2gw.Provider interface.

--- a/pkg/i2gw/providers/ingressnginx/resource_reader.go
+++ b/pkg/i2gw/providers/ingressnginx/resource_reader.go
@@ -26,20 +26,28 @@ import (
 
 // converter implements the i2gw.CustomResourceReader interface.
 type resourceReader struct {
-	conf *i2gw.ProviderConf
+	conf         *i2gw.ProviderConf
+	ingressClass string
 }
 
 // newResourceReader returns a resourceReader instance.
 func newResourceReader(conf *i2gw.ProviderConf) *resourceReader {
+	var ingressClass string
+
+	if ps := conf.ProviderSpecificFlags[Name]; ps != nil {
+		ingressClass = ps[NginxIngressClassFlag]
+	}
+
 	return &resourceReader{
-		conf: conf,
+		conf:         conf,
+		ingressClass: ingressClass,
 	}
 }
 
 func (r *resourceReader) readResourcesFromCluster(ctx context.Context) (*storage, error) {
 	storage := newResourcesStorage()
 
-	ingresses, err := common.ReadIngressesFromCluster(ctx, r.conf.Client, sets.New(NginxIngressClass))
+	ingresses, err := common.ReadIngressesFromCluster(ctx, r.conf.Client, sets.New(r.ingressClass))
 	if err != nil {
 		return nil, err
 	}
@@ -56,7 +64,7 @@ func (r *resourceReader) readResourcesFromCluster(ctx context.Context) (*storage
 func (r *resourceReader) readResourcesFromFile(filename string) (*storage, error) {
 	storage := newResourcesStorage()
 
-	ingresses, err := common.ReadIngressesFromFile(filename, r.conf.Namespace, sets.New(NginxIngressClass))
+	ingresses, err := common.ReadIngressesFromFile(filename, r.conf.Namespace, sets.New(r.ingressClass))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This allows users to select the ingress-nginx class if they use something other than the default 'nginx'

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

Allows users of ingress-nginx to specify the ingress class name.

**Which issue(s) this PR fixes**:
It solves a portion of https://github.com/kubernetes-sigs/ingress2gateway/issues/214

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Add parameter to ingress-nginx provider to select ingress class
```
