### PR TITLE
Do not print the table on stdout

### DIFF
--- a/cmd/print.go
+++ b/cmd/print.go
@@ -94,7 +94,7 @@ func (pr *PrintRunner) PrintGatewayAPIObjects(cmd *cobra.Command, _ []string) er
 	}
 
 	for _, table := range notificationTablesMap {
-		fmt.Println(table)
+		fmt.Fprintln(os.Stderr, table)
 	}
 
 	pr.outputResult(gatewayResources)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Stop printing the info table as part of the manifest. When we print to stdout the manifest becomes invalid and doing things like "ingress2gateway | kubectl apply -f -" won't work

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Print notification table on stderr
```
