### PR TITLE
Fix OIDC authentication support

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,6 +20,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 )
 
 // kubeconfig indicates kubeconfig file location.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,7 +20,6 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 )
 
 // kubeconfig indicates kubeconfig file location.

--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ package main
 
 import (
 	"github.com/kubernetes-sigs/ingress2gateway/cmd"
-	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package main
 
-import "github.com/kubernetes-sigs/ingress2gateway/cmd"
+import (
+	"github.com/kubernetes-sigs/ingress2gateway/cmd"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
+)
 
 func main() {
 	cmd.Execute()


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/ingress2gateway/blob/main/CONTRIBUTING.md). -->

<!-- The release notes and the kind will be used to generate the Changelog for the release. To make sure your contribution is recognized, please label this pull request according to what type of issue you are addressing and add the release notes when necessary (see ../CONTRIBUTING.md) -->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

The imports the k8s OIDC libraries so that OIDC authentication to the kubernetes apiserver works. At the moment, if you are trying to run `ingress2gateway` against a kubernetes cluster that is configured in your kubeconfig to use OIDC, you get the following error

```
$ ./ingress2gateway print --providers ingress-nginx
Error: failed to create client: no Auth Provider found for name "oidc"
...
```

Once the OIDC auth libraries are imported this now works fine

```
$ ./ingress2gateway print --providers ingress-nginx -n piperj
No resources found in piperj namespace
```

This should also fix GCP and Azure logins as well as those auth libraries are part of this fix as well.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #215

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Fix invocations for OIDC-enabled clusters from kubeconfig
```
