### PR TITLE
add ability to read input file from stdin

### DIFF
--- a/cmd/print.go
+++ b/cmd/print.go
@@ -327,7 +327,7 @@ func newPrintCommand() *cobra.Command {
 		"Output format. One of: (yaml, json, kyaml).")
 
 	cmd.Flags().StringVar(&pr.inputFile, "input-file", "",
-		`Path to the manifest file. When set, the tool will read ingresses from the file instead of reading from the cluster. Supported files are yaml and json.`)
+		`Path to the manifest file. Use "-" to read from stdin. When set, the tool will read ingresses from the file instead of reading from the cluster. Supported files are yaml and json.`)
 
 	cmd.Flags().StringVarP(&pr.namespace, "namespace", "n", "",
 		`If present, the namespace scope for this CLI request.`)

--- a/pkg/i2gw/providers/common/resource_reader.go
+++ b/pkg/i2gw/providers/common/resource_reader.go
@@ -53,9 +53,18 @@ func ReadIngressesFromCluster(ctx context.Context, client client.Client, ingress
 }
 
 func ReadIngressesFromFile(filename, namespace string, ingressClasses sets.Set[string]) (map[types.NamespacedName]*networkingv1.Ingress, error) {
-	stream, err := os.ReadFile(filename)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read file %v: %w", filename, err)
+	var stream []byte
+	var err error
+	if filename == "-" {
+		stream, err = io.ReadAll(os.Stdin)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read from stdin: %w", err)
+		}
+	} else {
+		stream, err = os.ReadFile(filename)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read file %v: %w", filename, err)
+		}
 	}
 
 	unstructuredObjects, err := ExtractObjectsFromReader(bytes.NewReader(stream), namespace)
@@ -98,9 +107,18 @@ func ReadServicesFromCluster(ctx context.Context, client client.Client) (map[typ
 }
 
 func ReadServicesFromFile(filename, namespace string) (map[types.NamespacedName]*apiv1.Service, error) {
-	stream, err := os.ReadFile(filename)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read file %v: %w", filename, err)
+	var stream []byte
+	var err error
+	if filename == "-" {
+		stream, err = io.ReadAll(os.Stdin)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read from stdin: %w", err)
+		}
+	} else {
+		stream, err = os.ReadFile(filename)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read file %v: %w", filename, err)
+		}
 	}
 
 	unstructuredObjects, err := ExtractObjectsFromReader(bytes.NewReader(stream), namespace)


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/ingress2gateway/blob/main/CONTRIBUTING.md). -->

<!-- The release notes and the kind will be used to generate the Changelog for the release. To make sure your contribution is recognized, please label this pull request according to what type of issue you are addressing and add the release notes when necessary (see ../CONTRIBUTING.md) -->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

This allows the tool to read input from `stdin` by using the special filename `-` (like kubectl does)

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
added ability to read input-file from stdin
```
