### PR TITLE
Ensures Gateway-API object fields obey kubebuilder max item validation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/sync v0.19.0
+	golang.org/x/tools v0.40.0
 	helm.sh/helm/v4 v4.0.4
 	istio.io/api v1.28.0
 	k8s.io/api v0.34.1
@@ -108,6 +109,7 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.46.0 // indirect
 	golang.org/x/exp v0.0.0-20251209150349-8475f28825e9 // indirect
+	golang.org/x/mod v0.31.0 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	k8s.io/apiserver v0.34.1 // indirect
 	k8s.io/component-base v0.34.1 // indirect

--- a/pkg/i2gw/ingress2gateway.go
+++ b/pkg/i2gw/ingress2gateway.go
@@ -100,6 +100,9 @@ func ToGatewayAPIResources(ctx context.Context, namespace string, inputFile stri
 		gatewayResources = append(gatewayResources, providerGatewayResources)
 	}
 	notificationTablesMap := notifications.NotificationAggr.CreateNotificationTables()
+	for _, gw := range gatewayResources {
+		errs = append(errs, ValidateMaxItems(&gw)...)
+	}
 	if len(errs) > 0 {
 		return nil, notificationTablesMap, aggregatedErrs(errs)
 	}

--- a/pkg/i2gw/validate.go
+++ b/pkg/i2gw/validate.go
@@ -1,0 +1,133 @@
+package i2gw
+
+import (
+	"fmt"
+	"go/ast"
+	"reflect"
+	"strconv"
+	"strings"
+
+	"golang.org/x/tools/go/packages"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+const (
+	KubebuilderMaxItemsMarker = "kubebuilder:validation:MaxItems"
+	MaxItemsPrefix            = "MaxItems="
+)
+
+// ValidateMaxItems validate fields presnet in the gateway resources object
+func ValidateMaxItems(gwResources *GatewayResources) field.ErrorList {
+	var errs field.ErrorList
+	maxItemsMap, err := loadGatewayAPITypes()
+	if err != nil {
+		return append(errs, field.InternalError(nil,
+			fmt.Errorf("unable to fetch kubebuilder max items : %v", err)))
+	}
+
+	for _, gw := range gwResources.Gateways {
+
+		if reflect.ValueOf(gw).IsZero() {
+			continue
+		}
+
+		v := reflect.ValueOf(gw)
+		if v.Kind() == reflect.Ptr {
+			//Get the struct
+			v = v.Elem()
+		}
+
+		spec := v.FieldByName("Spec")
+		if !spec.IsValid() || spec.IsZero() {
+			errs = append(errs, field.Required(
+				field.NewPath("spec"),
+				"spec field missing or empty in gateway resource",
+			))
+			return errs
+		}
+
+		gatewayErrs := validateSpecFields(spec, maxItemsMap, field.NewPath("spec"))
+		errs = append(errs, gatewayErrs...)
+
+	}
+	return errs
+}
+
+// validateSpecFields check fields in spec that are slices and whether exceeded max items limit
+func validateSpecFields(spec reflect.Value, maxItemsMap map[string]int, path *field.Path) field.ErrorList {
+	var errs field.ErrorList
+
+	t := spec.Type()
+
+	for i := 0; i < spec.NumField(); i++ {
+		fieldVal := spec.Field(i)
+		fieldType := t.Field(i)
+		fieldName := fieldType.Name
+
+		if fieldVal.Kind() == reflect.Slice && fieldVal.Len() > 0 {
+			if maxItems, exists := maxItemsMap[fieldName]; exists {
+				if fieldVal.Len() > maxItems {
+					errs = append(errs, field.TooMany(
+						path.Child(strings.ToLower(fieldName)),
+						fieldVal.Len(),
+						maxItems,
+					))
+				}
+			}
+		}
+	}
+
+	return errs
+}
+
+// loadGatewayAPITypes scans the Gateway API packages and extracts
+// the `+kubebuilder:validation:MaxItems` values defined in struct field comments
+func loadGatewayAPITypes() (map[string]int, error) {
+
+	cfg := &packages.Config{
+		Mode: packages.NeedFiles | packages.NeedSyntax,
+	}
+
+	pkgs, err := packages.Load(cfg,
+		"sigs.k8s.io/gateway-api/apis/v1",
+		"sigs.k8s.io/gateway-api/apis/v1alpha2",
+		"sigs.k8s.io/gateway-api/apis/v1beta1",
+		"sigs.k8s.io/gateway-api/apis/v1alpha3",
+	)
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to load gateway-api package: %w", err)
+	}
+
+	maxItemsMap := make(map[string]int)
+
+	for _, pkg := range pkgs {
+		for _, file := range pkg.Syntax {
+			ast.Inspect(file, func(n ast.Node) bool {
+				switch x := n.(type) {
+				case *ast.Field:
+					if x.Doc != nil {
+						for _, comment := range x.Doc.List {
+							if strings.Contains(comment.Text, KubebuilderMaxItemsMarker) {
+								fieldName := x.Names[0].Name
+								if strings.Contains(comment.Text, MaxItemsPrefix) {
+									parts := strings.Split(comment.Text, MaxItemsPrefix)
+									if len(parts) > 1 {
+										valueStr := strings.Split(parts[1], " ")[0]
+										if maxItems, err := strconv.Atoi(valueStr); err == nil {
+											maxItemsMap[fieldName] = maxItems
+										}
+
+									}
+								}
+							}
+						}
+					}
+				}
+				return true
+			})
+		}
+	}
+
+	return maxItemsMap, nil
+}

--- a/pkg/i2gw/validate_test.go
+++ b/pkg/i2gw/validate_test.go
@@ -1,0 +1,28 @@
+package i2gw
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func TestValidateMaxItems(t *testing.T) {
+
+	gwResources := &GatewayResources{
+		Gateways: map[types.NamespacedName]gatewayv1.Gateway{
+			{Namespace: "default", Name: "gw1"}: {
+				Spec: gatewayv1.GatewaySpec{
+					//Allowed Listeners is 64
+					Listeners: make([]gatewayv1.Listener, 65),
+				},
+			},
+		},
+	}
+
+	errs := ValidateMaxItems(gwResources)
+
+	if len(errs) < 1 {
+		t.Errorf("expected error, got %d", len(errs))
+	}
+}


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/ingress2gateway/blob/main/CONTRIBUTING.md). -->

<!-- The release notes and the kind will be used to generate the Changelog for the release. To make sure your contribution is recognized, please label this pull request according to what type of issue you are addressing and add the release notes when necessary (see ../CONTRIBUTING.md) -->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #124

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Added validation for Gateway API maxItems constraints. Now returns appropriate error messages when field limits are exceeded during I2GW conversion
```
