### PR TITLE
feat(conversion): enable best-effort output and silence usage on errors

### DIFF
--- a/cmd/print.go
+++ b/cmd/print.go
@@ -89,15 +89,20 @@ func (pr *PrintRunner) PrintGatewayAPIObjects(cmd *cobra.Command, _ []string) er
 	}
 
 	gatewayResources, notificationTablesMap, err := i2gw.ToGatewayAPIResources(cmd.Context(), pr.namespaceFilter, pr.inputFile, pr.providers, pr.getProviderSpecificFlags())
-	if err != nil {
-		return err
-	}
 
 	for _, table := range notificationTablesMap {
 		fmt.Fprintln(os.Stderr, table)
 	}
 
+	// Output partial results even if there are conversion errors (best-effort conversion)
 	pr.outputResult(gatewayResources)
+
+	// Return error after outputting partial results
+	if err != nil {
+		// Silence usage on conversion errors since these are not command usage errors
+		cmd.SilenceUsage = true
+		return err
+	}
 
 	return nil
 }

--- a/pkg/i2gw/ingress2gateway.go
+++ b/pkg/i2gw/ingress2gateway.go
@@ -84,7 +84,8 @@ func ToGatewayAPIResources(ctx context.Context, namespace string, inputFile stri
 	}
 	notificationTablesMap := notifications.NotificationAggr.CreateNotificationTables()
 	if len(errs) > 0 {
-		return nil, notificationTablesMap, aggregatedErrs(errs)
+		// Return partial results along with errors to support best-effort conversion
+		return gatewayResources, notificationTablesMap, aggregatedErrs(errs)
 	}
 
 	return gatewayResources, notificationTablesMap, nil

--- a/pkg/i2gw/providers/apisix/converter.go
+++ b/pkg/i2gw/providers/apisix/converter.go
@@ -50,9 +50,6 @@ func (c *resourcesToIRConverter) convertToIR(storage *storage) (intermediate.IR,
 	// Convert plain ingress resources to gateway resources, ignoring all
 	// provider-specific features.
 	ir, errs := common.ToIR(ingressList, storage.ServicePorts, c.implementationSpecificOptions)
-	if len(errs) > 0 {
-		return intermediate.IR{}, errs
-	}
 
 	for _, parseFeatureFunc := range c.featureParsers {
 		// Apply the feature parsing function to the gateway resources, one by one.

--- a/pkg/i2gw/providers/cilium/converter.go
+++ b/pkg/i2gw/providers/cilium/converter.go
@@ -50,9 +50,6 @@ func (c *resourcesToIRConverter) convertToIR(storage *storage) (intermediate.IR,
 	// Convert plain ingress resources to gateway resources, ignoring all
 	// provider-specific features.
 	ir, errs := common.ToIR(ingressList, storage.ServicePorts, c.implementationSpecificOptions)
-	if len(errs) > 0 {
-		return intermediate.IR{}, errs
-	}
 
 	for _, parseFeatureFunc := range c.featureParsers {
 		// Apply the feature parsing function to the gateway resources, one by one.

--- a/pkg/i2gw/providers/common/converter.go
+++ b/pkg/i2gw/providers/common/converter.go
@@ -51,9 +51,6 @@ func ToIR(ingresses []networkingv1.Ingress, servicePorts map[types.NamespacedNam
 	}
 
 	routes, gateways, errs := aggregator.toHTTPRoutesAndGateways(options)
-	if len(errs) > 0 {
-		return intermediate.IR{}, errs
-	}
 
 	routeByKey := make(map[types.NamespacedName]intermediate.HTTPRouteContext)
 	for _, routeWithSources := range routes {
@@ -81,7 +78,7 @@ func ToIR(ingresses []networkingv1.Ingress, servicePorts map[types.NamespacedNam
 		GRPCRoutes:         make(map[types.NamespacedName]gatewayv1.GRPCRoute),
 		BackendTLSPolicies: make(map[types.NamespacedName]gatewayv1.BackendTLSPolicy),
 		ReferenceGrants:    make(map[types.NamespacedName]gatewayv1beta1.ReferenceGrant),
-	}, nil
+	}, errs
 }
 
 var (

--- a/pkg/i2gw/providers/ingressnginx/converter.go
+++ b/pkg/i2gw/providers/ingressnginx/converter.go
@@ -45,9 +45,6 @@ func (c *resourcesToIRConverter) convert(storage *storage) (intermediate.IR, fie
 	// Convert plain ingress resources to gateway resources, ignoring all
 	// provider-specific features.
 	ir, errs := common.ToIR(ingressList, storage.ServicePorts, i2gw.ProviderImplementationSpecificOptions{})
-	if len(errs) > 0 {
-		return intermediate.IR{}, errs
-	}
 
 	for _, parseFeatureFunc := range c.featureParsers {
 		// Apply the feature parsing function to the gateway resources, one by one.

--- a/pkg/i2gw/providers/ingressnginx/converter_test.go
+++ b/pkg/i2gw/providers/ingressnginx/converter_test.go
@@ -337,7 +337,42 @@ func Test_ToIR(t *testing.T) {
 					},
 				},
 			},
-			expectedIR: intermediate.IR{},
+			expectedIR: intermediate.IR{
+				Gateways: map[types.NamespacedName]intermediate.GatewayContext{
+					{Namespace: "default", Name: "ingress-nginx"}: {
+						Gateway: gatewayv1.Gateway{
+							ObjectMeta: metav1.ObjectMeta{Name: "ingress-nginx", Namespace: "default"},
+							Spec: gatewayv1.GatewaySpec{
+								GatewayClassName: "ingress-nginx",
+								Listeners: []gatewayv1.Listener{{
+									Name:     "test-mydomain-com-http",
+									Port:     80,
+									Protocol: gatewayv1.HTTPProtocolType,
+									Hostname: ptrTo(gatewayv1.Hostname("test.mydomain.com")),
+								}},
+							},
+						},
+					},
+				},
+				HTTPRoutes: map[types.NamespacedName]intermediate.HTTPRouteContext{
+					{Namespace: "default", Name: "implementation-specific-regex-test-mydomain-com"}: {
+						HTTPRoute: gatewayv1.HTTPRoute{
+							ObjectMeta: metav1.ObjectMeta{Name: "implementation-specific-regex-test-mydomain-com", Namespace: "default"},
+							Spec: gatewayv1.HTTPRouteSpec{
+								CommonRouteSpec: gatewayv1.CommonRouteSpec{
+									ParentRefs: []gatewayv1.ParentReference{{
+										Name: "ingress-nginx",
+									}},
+								},
+								Hostnames: []gatewayv1.Hostname{"test.mydomain.com"},
+								// Rules is empty because the path conversion failed
+								Rules: []gatewayv1.HTTPRouteRule{},
+							},
+						},
+						RuleBackendSources: [][]intermediate.BackendSource{},
+					},
+				},
+			},
 			expectedErrors: field.ErrorList{
 				{
 					Type:     field.ErrorTypeInvalid,

--- a/pkg/i2gw/providers/nginx/converter.go
+++ b/pkg/i2gw/providers/nginx/converter.go
@@ -57,9 +57,6 @@ func (c *resourcesToIRConverter) convert(storage *storage) (intermediate.IR, fie
 	}
 
 	ir, errorList := common.ToIR(ingressList, storage.ServicePorts, c.implementationSpecificOptions)
-	if len(errorList) > 0 {
-		return intermediate.IR{}, errorList
-	}
 
 	for _, parseFeatureFunc := range c.featureParsers {
 		errs := parseFeatureFunc(ingressList, storage.ServicePorts, &ir)


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This PR improves the error handling behavior of the `ingress2gateway print` command to support best-effort conversion:

1. **Removes usage display on errors**: When conversion errors occur, the usage information is no longer displayed, providing cleaner error output.
2. **Enables best-effort conversion**: The tool now continues processing and outputs valid converted resources even when some resources contain errors, respecting the `--output` format flag.

Previously, when encountering errors (e.g., unsupported `ImplementationSpecific` pathType), the command would:

- Display the full usage help, cluttering the error output
- Not output any successfully converted resources in the requested format

After this change, the command:

- Shows only the error messages without usage information
- Continues conversion and outputs all valid resources in the requested format (YAML/JSON)
- Displays errors at the end for visibility

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**: Yes

```release-note
The `ingress2gateway print` command now supports best-effort conversion, continuing to output valid resources even when errors are encountered. Error output no longer includes usage information for cleaner display.
```

---

## Testing

To test this PR, use the following command with a file containing both valid and invalid resources:

```bash
./ingress2gateway print --input-file best-effort-input.yaml --providers ingress-nginx --output yaml
```

### Test Input (best-effort-input.yaml)

```yaml
apiVersion: v1
kind: Service
metadata:
  name: valid-service
  namespace: test
spec:
  ports:
  - port: 80
    targetPort: 8080
    name: http
---
apiVersion: v1
kind: Service
metadata:
  name: invalid-service
  namespace: test
spec:
  ports:
  - port: 80
    targetPort: invalid-port
    name: http
---
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: valid-ingress
  namespace: test
spec:
  ingressClassName: test-class
  rules:
  - host: valid.example.com
    http:
      paths:
      - path: /valid
        pathType: Prefix
        backend:
          service:
            name: valid-service
            port:
              number: 80
---
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: invalid-backend-ingress
  namespace: test
spec:
  ingressClassName: test-class
  rules:
  - host: invalid.example.com
    http:
      paths:
      - path: /invalid
        pathType: Prefix
        backend:
          service:
            name: invalid-service
            port:
              name: non-existent-port
```

### Expected Output

The command should output valid converted Gateway and HTTPRoute resources in YAML format, followed by error messages:

```text
apiVersion: gateway.networking.k8s.io/v1
kind: Gateway
metadata:
  annotations:
    gateway.networking.k8s.io/generator: ingress2gateway-v0.5.0-rc1-2-g1877e50-dirty
  name: nginx
  namespace: default
spec:
  gatewayClassName: nginx
  listeners:
  - hostname: nginx.example.com
    name: nginx-example-com-http
    port: 80
    protocol: HTTP
status: {}
---
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  annotations:
    gateway.networking.k8s.io/generator: ingress2gateway-v0.5.0-rc1-2-g1877e50-dirty
  name: test-nginx-nginx-example-com
  namespace: default
spec:
  hostnames:
  - nginx.example.com
  parentRefs:
  - name: nginx
status:
  parents: []
Error:

# Encountered 1 errors # spec.rules[0].http.paths[0].pathType: Invalid value: "ImplementationSpecific": implementationSpecific path type is not supported in generic translation, and your provider does not provide custom support to translate it
```
