### PR TITLE
Fix data race in NotificationAggregator

### DIFF
--- a/pkg/i2gw/notifications/notifications.go
+++ b/pkg/i2gw/notifications/notifications.go
@@ -63,6 +63,9 @@ func (na *NotificationAggregator) DispatchNotification(notification Notification
 func (na *NotificationAggregator) CreateNotificationTables() map[string]string {
 	notificationTablesMap := make(map[string]string)
 
+	na.mutex.Lock()
+	defer na.mutex.Unlock()
+
 	for provider, msgs := range na.Notifications {
 		providerTable := strings.Builder{}
 


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/ingress2gateway/blob/main/CONTRIBUTING.md). -->

<!-- The release notes and the kind will be used to generate the Changelog for the release. To make sure your contribution is recognized, please label this pull request according to what type of issue you are addressing and add the release notes when necessary (see ../CONTRIBUTING.md) -->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

**What this PR does / why we need it**:

I've stumbled upon a data race in NotificationAggregator while working on e2e tests for ingress2gateway. This fixes it.

To test the PR, run `make test` while commenting out the mutex lock in `CreateNotificationTables()`. This should make the test fail.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
None

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
