### PR TITLE
fix: setting proper secret group and kind in certificateRefs

### DIFF
--- a/pkg/i2gw/providers/common/converter.go
+++ b/pkg/i2gw/providers/common/converter.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/ptr"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
@@ -229,7 +230,11 @@ func (a *ingressAggregator) toHTTPRoutesAndGateways(options i2gw.ProviderImpleme
 		}
 		for _, tls := range rg.tls {
 			listener.TLS.CertificateRefs = append(listener.TLS.CertificateRefs,
-				gatewayv1.SecretObjectReference{Name: gatewayv1.ObjectName(tls.SecretName)})
+				gatewayv1.SecretObjectReference{
+					Group: ptr.To(gatewayv1.Group("")),
+					Kind:  ptr.To(gatewayv1.Kind("Secret")),
+					Name:  gatewayv1.ObjectName(tls.SecretName),
+				})
 		}
 		gwKey := fmt.Sprintf("%s/%s", rg.namespace, rg.ingressClass)
 		listenersByNamespacedGateway[gwKey] = append(listenersByNamespacedGateway[gwKey], listener)

--- a/pkg/i2gw/providers/common/converter_test.go
+++ b/pkg/i2gw/providers/common/converter_test.go
@@ -29,6 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/ptr"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
@@ -182,7 +183,9 @@ func Test_ToIR(t *testing.T) {
 									Hostname: PtrTo(gatewayv1.Hostname("example.com")),
 									TLS: &gatewayv1.ListenerTLSConfig{
 										CertificateRefs: []gatewayv1.SecretObjectReference{{
-											Name: "example-cert",
+											Group: ptr.To(gatewayv1.Group("")),
+											Kind:  ptr.To(gatewayv1.Kind("Secret")),
+											Name:  "example-cert",
 										}},
 									},
 								}},

--- a/pkg/i2gw/providers/ingressnginx/converter_test.go
+++ b/pkg/i2gw/providers/ingressnginx/converter_test.go
@@ -438,7 +438,11 @@ func Test_ToIR(t *testing.T) {
 										Hostname: ptrTo(gatewayv1.Hostname("bar.example.com")),
 										TLS: &gatewayv1.ListenerTLSConfig{
 											CertificateRefs: []gatewayv1.SecretObjectReference{
-												{Name: "example-com"},
+												{
+													Group: ptrTo(gatewayv1.Group("")),
+													Kind:  ptrTo(gatewayv1.Kind("Secret")),
+													Name:  "example-com",
+												},
 											},
 										},
 									},
@@ -455,7 +459,11 @@ func Test_ToIR(t *testing.T) {
 										Hostname: ptrTo(gatewayv1.Hostname("foo.example.com")),
 										TLS: &gatewayv1.ListenerTLSConfig{
 											CertificateRefs: []gatewayv1.SecretObjectReference{
-												{Name: "example-com"},
+												{
+													Group: ptrTo(gatewayv1.Group("")),
+													Kind:  ptrTo(gatewayv1.Kind("Secret")),
+													Name:  "example-com",
+												},
 											},
 										},
 									},

--- a/pkg/i2gw/providers/nginx/annotations/listen_ports.go
+++ b/pkg/i2gw/providers/nginx/annotations/listen_ports.go
@@ -150,6 +150,8 @@ func replaceGatewayPortsWithCustom(ingress networkingv1.Ingress, portConfigurati
 					Mode: common.PtrTo(gatewayv1.TLSModeTerminate),
 					CertificateRefs: []gatewayv1.SecretObjectReference{
 						{
+							Group:     common.PtrTo(gatewayv1.Group("")),
+							Kind:      common.PtrTo(gatewayv1.Kind("Secret")),
 							Name:      gatewayv1.ObjectName(ingress.Spec.TLS[0].SecretName),
 							Namespace: (*gatewayv1.Namespace)(&ingress.Namespace),
 						},

--- a/pkg/i2gw/providers/nginx/annotations/ssl_redirect.go
+++ b/pkg/i2gw/providers/nginx/annotations/ssl_redirect.go
@@ -112,7 +112,11 @@ func ensureHTTPSListener(ingress networkingv1.Ingress, rule networkingv1.Ingress
 		TLS: &gatewayv1.ListenerTLSConfig{
 			Mode: ptr.To(gatewayv1.TLSModeTerminate),
 			CertificateRefs: []gatewayv1.SecretObjectReference{
-				{Name: gatewayv1.ObjectName(fmt.Sprintf("%s-tls", strings.ReplaceAll(rule.Host, ".", "-")))},
+				{
+					Group: ptr.To(gatewayv1.Group("")),
+					Kind:  ptr.To(gatewayv1.Kind("Secret")),
+					Name:  gatewayv1.ObjectName(fmt.Sprintf("%s-tls", strings.ReplaceAll(rule.Host, ".", "-"))),
+				},
 			},
 		},
 	}

--- a/pkg/i2gw/providers/nginx/fixtures/annotations/output/nginx-hsts.yaml
+++ b/pkg/i2gw/providers/nginx/fixtures/annotations/output/nginx-hsts.yaml
@@ -19,8 +19,8 @@ spec:
     protocol: HTTPS
     tls:
       certificateRefs:
-      - group: null
-        kind: null
+      - group: ""
+        kind: Secret
         name: hsts-tls
 status: {}
 ---

--- a/pkg/i2gw/providers/nginx/fixtures/annotations/output/nginx-listen-ports.yaml
+++ b/pkg/i2gw/providers/nginx/fixtures/annotations/output/nginx-listen-ports.yaml
@@ -15,8 +15,8 @@ spec:
     protocol: HTTPS
     tls:
       certificateRefs:
-      - group: null
-        kind: null
+      - group: ""
+        kind: Secret
         name: custom-ports-tls
         namespace: default
       mode: Terminate


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/ingress2gateway/blob/main/CONTRIBUTING.md). -->

<!-- The release notes and the kind will be used to generate the Changelog for the release. To make sure your contribution is recognized, please label this pull request according to what type of issue you are addressing and add the release notes when necessary (see ../CONTRIBUTING.md) -->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug
**What this PR does / why we need it**:

This PR fixes generating null values for group and kind for SecretObjectReference in CertificateRefs.
I have migrated resources on my cluster and did notice certificateRefs being translated to this.
```yaml
      certificateRefs:
      - group: null
        kind: null
        name: tls-sectet
```
I know that there are defaults set in the gateway-api, but it is still a bit confusing, and I think it should not rely fully on defaulting.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
