### PR TITLE
feat(ingressnginx): implement timeout annotation support

### DIFF
--- a/pkg/i2gw/providers/ingressnginx/annotations.go
+++ b/pkg/i2gw/providers/ingressnginx/annotations.go
@@ -36,4 +36,15 @@ const (
 
 	// SSL Redirect annotation
 	SSLRedirectAnnotation = "nginx.ingress.kubernetes.io/ssl-redirect"
+
+	// Timeout annotations
+	ProxyConnectTimeoutAnnotation      = "nginx.ingress.kubernetes.io/proxy-connect-timeout"
+	ProxySendTimeoutAnnotation         = "nginx.ingress.kubernetes.io/proxy-send-timeout"
+	ProxyReadTimeoutAnnotation         = "nginx.ingress.kubernetes.io/proxy-read-timeout"
+	ProxyNextUpstreamAnnotation        = "nginx.ingress.kubernetes.io/proxy-next-upstream"
+	ProxyNextUpstreamTimeoutAnnotation = "nginx.ingress.kubernetes.io/proxy-next-upstream-timeout"
+	ProxyNextUpstreamTriesAnnotation   = "nginx.ingress.kubernetes.io/proxy-next-upstream-tries"
+
+	// Proxy body size annotation (not a timeout, but related to proxy configuration)
+	ProxyBodySizeAnnotation = "nginx.ingress.kubernetes.io/proxy-body-size"
 )

--- a/pkg/i2gw/providers/ingressnginx/converter.go
+++ b/pkg/i2gw/providers/ingressnginx/converter.go
@@ -34,6 +34,7 @@ func newResourcesToIRConverter() *resourcesToIRConverter {
 		featureParsers: []i2gw.FeatureParser{
 			canaryFeature,
 			headerModifierFeature,
+			timeoutFeature,
 		},
 	}
 }

--- a/pkg/i2gw/providers/ingressnginx/timeout.go
+++ b/pkg/i2gw/providers/ingressnginx/timeout.go
@@ -1,0 +1,186 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ingressnginx
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw/notifications"
+	providerir "github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw/provider_intermediate"
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+// durationRegex validates Gateway API Duration format per GEP-2257.
+// Valid format: one or more of <digits>(h|m|s|ms) where digits is 1-5 digits.
+var durationRegex = regexp.MustCompile(`^([0-9]{1,5}(h|m|s|ms)){1,4}$`)
+
+// timeoutFeature parses timeout annotations from ingress-nginx and applies
+// them to HTTPRoute rules as Gateway API HTTPRouteTimeouts.
+//
+// Timeout mapping rationale:
+//   - proxy-read-timeout -> Request timeout (total time for request lifecycle)
+//   - proxy-connect-timeout -> BackendRequest timeout (time to establish backend connection)
+//
+// Note: nginx-ingress proxy-read-timeout is technically the time to read a response
+// from the backend, but Gateway API's Request timeout is the closest semantic match
+// for controlling overall request duration that users typically care about.
+func timeoutFeature(_ []networkingv1.Ingress, _ map[types.NamespacedName]map[string]int32, ir *providerir.ProviderIR) field.ErrorList {
+	var errs field.ErrorList
+
+	for _, httpRouteContext := range ir.HTTPRoutes {
+		for i := range httpRouteContext.HTTPRoute.Spec.Rules {
+			if i >= len(httpRouteContext.RuleBackendSources) {
+				continue
+			}
+			sources := httpRouteContext.RuleBackendSources[i]
+
+			ingress := getNonCanaryIngress(sources)
+			if ingress == nil {
+				continue
+			}
+
+			timeouts, parseErrs := parseTimeoutAnnotations(ingress, &httpRouteContext.HTTPRoute)
+			errs = append(errs, parseErrs...)
+
+			// Apply valid timeouts even if some annotations had errors
+			if timeouts != nil && (timeouts.Request != nil || timeouts.BackendRequest != nil) {
+				httpRouteContext.HTTPRoute.Spec.Rules[i].Timeouts = timeouts
+				notify(notifications.InfoNotification, fmt.Sprintf("Applied timeout configuration to rule %d of route %s/%s", i, httpRouteContext.HTTPRoute.Namespace, httpRouteContext.HTTPRoute.Name), &httpRouteContext.HTTPRoute)
+			}
+
+			// Warn about unsupported annotations
+			warnUnsupportedTimeoutAnnotations(ingress, &httpRouteContext.HTTPRoute)
+		}
+	}
+
+	if len(errs) > 0 {
+		return errs
+	}
+	return nil
+}
+
+// parseTimeoutAnnotations parses timeout-related annotations and returns HTTPRouteTimeouts.
+// It continues parsing valid annotations even if some have errors.
+func parseTimeoutAnnotations(ingress *networkingv1.Ingress, httpRoute *gatewayv1.HTTPRoute) (*gatewayv1.HTTPRouteTimeouts, field.ErrorList) {
+	var errs field.ErrorList
+	var timeouts *gatewayv1.HTTPRouteTimeouts
+
+	// Parse proxy-read-timeout -> Request timeout
+	// Maps to the overall request timeout in Gateway API
+	if val, ok := ingress.Annotations[ProxyReadTimeoutAnnotation]; ok && val != "" {
+		duration, err := parseTimeoutValue(val)
+		if err != nil {
+			errs = append(errs, field.Invalid(
+				field.NewPath("ingress", ingress.Namespace, ingress.Name, "metadata", "annotations", ProxyReadTimeoutAnnotation),
+				val,
+				fmt.Sprintf("invalid timeout value: %v", err),
+			))
+		} else {
+			if timeouts == nil {
+				timeouts = &gatewayv1.HTTPRouteTimeouts{}
+			}
+			timeouts.Request = duration
+			notify(notifications.InfoNotification, fmt.Sprintf("Ingress %s/%s: parsed proxy-read-timeout=%s as Request timeout", ingress.Namespace, ingress.Name, val), httpRoute)
+		}
+	}
+
+	// Parse proxy-connect-timeout -> BackendRequest timeout
+	// Maps to the backend connection timeout in Gateway API
+	if val, ok := ingress.Annotations[ProxyConnectTimeoutAnnotation]; ok && val != "" {
+		duration, err := parseTimeoutValue(val)
+		if err != nil {
+			errs = append(errs, field.Invalid(
+				field.NewPath("ingress", ingress.Namespace, ingress.Name, "metadata", "annotations", ProxyConnectTimeoutAnnotation),
+				val,
+				fmt.Sprintf("invalid timeout value: %v", err),
+			))
+		} else {
+			if timeouts == nil {
+				timeouts = &gatewayv1.HTTPRouteTimeouts{}
+			}
+			timeouts.BackendRequest = duration
+			notify(notifications.InfoNotification, fmt.Sprintf("Ingress %s/%s: parsed proxy-connect-timeout=%s as BackendRequest timeout", ingress.Namespace, ingress.Name, val), httpRoute)
+		}
+	}
+
+	// proxy-send-timeout is logged as info since Gateway API doesn't have a direct equivalent
+	if val, ok := ingress.Annotations[ProxySendTimeoutAnnotation]; ok && val != "" {
+		notify(notifications.InfoNotification, fmt.Sprintf("Ingress %s/%s: proxy-send-timeout=%s noted (no direct Gateway API equivalent)", ingress.Namespace, ingress.Name, val), httpRoute)
+	}
+
+	return timeouts, errs
+}
+
+// parseTimeoutValue converts a timeout string (in seconds or with suffix) to Gateway API Duration.
+// Accepts:
+//   - Plain integers (treated as seconds): "60" -> "60s"
+//   - Duration strings with suffix: "30s", "5m", "1h", "500ms"
+//   - Combined durations: "1h30m", "1m30s"
+func parseTimeoutValue(val string) (*gatewayv1.Duration, error) {
+	val = strings.TrimSpace(val)
+	if val == "" {
+		return nil, fmt.Errorf("empty timeout value")
+	}
+
+	// Check if value has a duration suffix (h, m, s, or ms)
+	hasDurationSuffix := strings.HasSuffix(val, "s") || strings.HasSuffix(val, "m") || strings.HasSuffix(val, "h")
+
+	if hasDurationSuffix {
+		// Validate against Gateway API Duration format per GEP-2257
+		if !durationRegex.MatchString(val) {
+			return nil, fmt.Errorf("invalid Gateway API duration format: %q (must match pattern like '30s', '5m', '1h', '500ms')", val)
+		}
+		d := gatewayv1.Duration(val)
+		return &d, nil
+	}
+
+	// nginx-ingress timeout values are in seconds by default
+	seconds, err := strconv.Atoi(val)
+	if err != nil {
+		return nil, fmt.Errorf("cannot parse %q as seconds: %v", val, err)
+	}
+
+	if seconds < 0 {
+		return nil, fmt.Errorf("timeout cannot be negative: %d", seconds)
+	}
+
+	d := gatewayv1.Duration(fmt.Sprintf("%ds", seconds))
+	return &d, nil
+}
+
+// warnUnsupportedTimeoutAnnotations logs warnings for annotations that don't have
+// direct Gateway API equivalents
+func warnUnsupportedTimeoutAnnotations(ingress *networkingv1.Ingress, httpRoute *gatewayv1.HTTPRoute) {
+	unsupportedAnnotations := map[string]string{
+		ProxyNextUpstreamAnnotation:        "proxy-next-upstream (retry policy) is not directly supported in Gateway API HTTPRoute",
+		ProxyNextUpstreamTimeoutAnnotation: "proxy-next-upstream-timeout is not directly supported in Gateway API HTTPRoute",
+		ProxyNextUpstreamTriesAnnotation:   "proxy-next-upstream-tries is not directly supported in Gateway API HTTPRoute",
+		ProxyBodySizeAnnotation:            "proxy-body-size is not directly supported in Gateway API HTTPRoute",
+	}
+
+	for annotation, message := range unsupportedAnnotations {
+		if val, ok := ingress.Annotations[annotation]; ok && val != "" {
+			notify(notifications.WarningNotification, fmt.Sprintf("Ingress %s/%s: %s (value: %s)", ingress.Namespace, ingress.Name, message, val), httpRoute)
+		}
+	}
+}

--- a/pkg/i2gw/providers/ingressnginx/timeout_test.go
+++ b/pkg/i2gw/providers/ingressnginx/timeout_test.go
@@ -1,0 +1,494 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ingressnginx
+
+import (
+	"testing"
+
+	providerir "github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw/provider_intermediate"
+	"github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw/providers/common"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func TestParseTimeoutValue(t *testing.T) {
+	testCases := []struct {
+		name        string
+		input       string
+		expected    string
+		expectError bool
+	}{
+		{
+			name:        "seconds as integer",
+			input:       "60",
+			expected:    "60s",
+			expectError: false,
+		},
+		{
+			name:        "seconds with suffix",
+			input:       "30s",
+			expected:    "30s",
+			expectError: false,
+		},
+		{
+			name:        "minutes with suffix",
+			input:       "5m",
+			expected:    "5m",
+			expectError: false,
+		},
+		{
+			name:        "hours with suffix",
+			input:       "1h",
+			expected:    "1h",
+			expectError: false,
+		},
+		{
+			name:        "milliseconds with suffix",
+			input:       "500ms",
+			expected:    "500ms",
+			expectError: false,
+		},
+		{
+			name:        "combined duration",
+			input:       "1h30m",
+			expected:    "1h30m",
+			expectError: false,
+		},
+		{
+			name:        "combined duration with seconds",
+			input:       "5m30s",
+			expected:    "5m30s",
+			expectError: false,
+		},
+		{
+			name:        "zero seconds",
+			input:       "0",
+			expected:    "0s",
+			expectError: false,
+		},
+		{
+			name:        "zero with suffix",
+			input:       "0s",
+			expected:    "0s",
+			expectError: false,
+		},
+		{
+			name:        "whitespace trimmed",
+			input:       "  60  ",
+			expected:    "60s",
+			expectError: false,
+		},
+		{
+			name:        "negative value",
+			input:       "-1",
+			expected:    "",
+			expectError: true,
+		},
+		{
+			name:        "empty value",
+			input:       "",
+			expected:    "",
+			expectError: true,
+		},
+		{
+			name:        "invalid value",
+			input:       "abc",
+			expected:    "",
+			expectError: true,
+		},
+		{
+			name:        "invalid format with suffix",
+			input:       "abc123s",
+			expected:    "",
+			expectError: true,
+		},
+		{
+			name:        "negative with suffix",
+			input:       "-5s",
+			expected:    "",
+			expectError: true,
+		},
+		{
+			name:        "decimal value",
+			input:       "1.5s",
+			expected:    "",
+			expectError: true,
+		},
+		{
+			name:        "too many digits",
+			input:       "999999s",
+			expected:    "",
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := parseTimeoutValue(tc.input)
+			if tc.expectError {
+				if err == nil {
+					t.Fatalf("Expected error but got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Expected no error, got: %v", err)
+			}
+			if string(*result) != tc.expected {
+				t.Errorf("Expected %s, got %s", tc.expected, string(*result))
+			}
+		})
+	}
+}
+
+func TestTimeoutFeature(t *testing.T) {
+	testCases := []struct {
+		name                   string
+		ingress                networkingv1.Ingress
+		expectedRequest        *gatewayv1.Duration
+		expectedBackendRequest *gatewayv1.Duration
+		expectError            bool
+	}{
+		{
+			name: "proxy-read-timeout sets Request timeout",
+			ingress: networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-read-timeout",
+					Namespace: "default",
+					Annotations: map[string]string{
+						ProxyReadTimeoutAnnotation: "60",
+					},
+				},
+				Spec: networkingv1.IngressSpec{
+					Rules: []networkingv1.IngressRule{
+						{
+							Host: "example.com",
+							IngressRuleValue: networkingv1.IngressRuleValue{
+								HTTP: &networkingv1.HTTPIngressRuleValue{
+									Paths: []networkingv1.HTTPIngressPath{
+										{
+											Path:     "/",
+											PathType: ptr.To(networkingv1.PathTypePrefix),
+											Backend: networkingv1.IngressBackend{
+												Service: &networkingv1.IngressServiceBackend{
+													Name: "test-service",
+													Port: networkingv1.ServiceBackendPort{
+														Number: 80,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedRequest:        ptr.To(gatewayv1.Duration("60s")),
+			expectedBackendRequest: nil,
+			expectError:            false,
+		},
+		{
+			name: "proxy-connect-timeout sets BackendRequest timeout",
+			ingress: networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-connect-timeout",
+					Namespace: "default",
+					Annotations: map[string]string{
+						ProxyConnectTimeoutAnnotation: "30",
+					},
+				},
+				Spec: networkingv1.IngressSpec{
+					Rules: []networkingv1.IngressRule{
+						{
+							Host: "example.com",
+							IngressRuleValue: networkingv1.IngressRuleValue{
+								HTTP: &networkingv1.HTTPIngressRuleValue{
+									Paths: []networkingv1.HTTPIngressPath{
+										{
+											Path:     "/",
+											PathType: ptr.To(networkingv1.PathTypePrefix),
+											Backend: networkingv1.IngressBackend{
+												Service: &networkingv1.IngressServiceBackend{
+													Name: "test-service",
+													Port: networkingv1.ServiceBackendPort{
+														Number: 80,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedRequest:        nil,
+			expectedBackendRequest: ptr.To(gatewayv1.Duration("30s")),
+			expectError:            false,
+		},
+		{
+			name: "both timeouts set",
+			ingress: networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-both-timeouts",
+					Namespace: "default",
+					Annotations: map[string]string{
+						ProxyReadTimeoutAnnotation:    "120",
+						ProxyConnectTimeoutAnnotation: "10",
+					},
+				},
+				Spec: networkingv1.IngressSpec{
+					Rules: []networkingv1.IngressRule{
+						{
+							Host: "example.com",
+							IngressRuleValue: networkingv1.IngressRuleValue{
+								HTTP: &networkingv1.HTTPIngressRuleValue{
+									Paths: []networkingv1.HTTPIngressPath{
+										{
+											Path:     "/",
+											PathType: ptr.To(networkingv1.PathTypePrefix),
+											Backend: networkingv1.IngressBackend{
+												Service: &networkingv1.IngressServiceBackend{
+													Name: "test-service",
+													Port: networkingv1.ServiceBackendPort{
+														Number: 80,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedRequest:        ptr.To(gatewayv1.Duration("120s")),
+			expectedBackendRequest: ptr.To(gatewayv1.Duration("10s")),
+			expectError:            false,
+		},
+		{
+			name: "timeout with duration suffix",
+			ingress: networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-duration-suffix",
+					Namespace: "default",
+					Annotations: map[string]string{
+						ProxyReadTimeoutAnnotation: "5m",
+					},
+				},
+				Spec: networkingv1.IngressSpec{
+					Rules: []networkingv1.IngressRule{
+						{
+							Host: "example.com",
+							IngressRuleValue: networkingv1.IngressRuleValue{
+								HTTP: &networkingv1.HTTPIngressRuleValue{
+									Paths: []networkingv1.HTTPIngressPath{
+										{
+											Path:     "/",
+											PathType: ptr.To(networkingv1.PathTypePrefix),
+											Backend: networkingv1.IngressBackend{
+												Service: &networkingv1.IngressServiceBackend{
+													Name: "test-service",
+													Port: networkingv1.ServiceBackendPort{
+														Number: 80,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedRequest:        ptr.To(gatewayv1.Duration("5m")),
+			expectedBackendRequest: nil,
+			expectError:            false,
+		},
+		{
+			name: "no timeout annotations",
+			ingress: networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-no-timeouts",
+					Namespace: "default",
+				},
+				Spec: networkingv1.IngressSpec{
+					Rules: []networkingv1.IngressRule{
+						{
+							Host: "example.com",
+							IngressRuleValue: networkingv1.IngressRuleValue{
+								HTTP: &networkingv1.HTTPIngressRuleValue{
+									Paths: []networkingv1.HTTPIngressPath{
+										{
+											Path:     "/",
+											PathType: ptr.To(networkingv1.PathTypePrefix),
+											Backend: networkingv1.IngressBackend{
+												Service: &networkingv1.IngressServiceBackend{
+													Name: "test-service",
+													Port: networkingv1.ServiceBackendPort{
+														Number: 80,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedRequest:        nil,
+			expectedBackendRequest: nil,
+			expectError:            false,
+		},
+		{
+			name: "invalid timeout value",
+			ingress: networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-invalid-timeout",
+					Namespace: "default",
+					Annotations: map[string]string{
+						ProxyReadTimeoutAnnotation: "invalid",
+					},
+				},
+				Spec: networkingv1.IngressSpec{
+					Rules: []networkingv1.IngressRule{
+						{
+							Host: "example.com",
+							IngressRuleValue: networkingv1.IngressRuleValue{
+								HTTP: &networkingv1.HTTPIngressRuleValue{
+									Paths: []networkingv1.HTTPIngressPath{
+										{
+											Path:     "/",
+											PathType: ptr.To(networkingv1.PathTypePrefix),
+											Backend: networkingv1.IngressBackend{
+												Service: &networkingv1.IngressServiceBackend{
+													Name: "test-service",
+													Port: networkingv1.ServiceBackendPort{
+														Number: 80,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedRequest:        nil,
+			expectedBackendRequest: nil,
+			expectError:            true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ir := providerir.ProviderIR{
+				HTTPRoutes: make(map[types.NamespacedName]providerir.HTTPRouteContext),
+			}
+
+			key := types.NamespacedName{Namespace: tc.ingress.Namespace, Name: common.RouteName(tc.ingress.Name, "example.com")}
+			route := gatewayv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: tc.ingress.Namespace,
+					Name:      key.Name,
+				},
+				Spec: gatewayv1.HTTPRouteSpec{
+					Rules: []gatewayv1.HTTPRouteRule{
+						{
+							Matches: []gatewayv1.HTTPRouteMatch{
+								{
+									Path: &gatewayv1.HTTPPathMatch{
+										Type:  ptr.To(gatewayv1.PathMatchPathPrefix),
+										Value: ptr.To("/"),
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			ir.HTTPRoutes[key] = providerir.HTTPRouteContext{
+				HTTPRoute: route,
+				RuleBackendSources: [][]providerir.BackendSource{
+					{
+						{Ingress: &tc.ingress},
+					},
+				},
+			}
+
+			errs := timeoutFeature([]networkingv1.Ingress{tc.ingress}, nil, &ir)
+			if tc.expectError {
+				if len(errs) == 0 {
+					t.Fatalf("Expected errors but got none")
+				}
+				return
+			}
+			if len(errs) > 0 {
+				t.Fatalf("Expected no errors, got %v", errs)
+			}
+
+			result := ir.HTTPRoutes[key]
+			rules := result.HTTPRoute.Spec.Rules
+			if len(rules) != 1 {
+				t.Fatalf("Expected 1 rule, got %d", len(rules))
+			}
+
+			timeouts := rules[0].Timeouts
+
+			if tc.expectedRequest == nil && tc.expectedBackendRequest == nil {
+				if timeouts != nil {
+					t.Fatalf("Expected no timeouts, but got %+v", timeouts)
+				}
+				return
+			}
+
+			if timeouts == nil {
+				t.Fatalf("Expected timeouts to be set")
+			}
+
+			if tc.expectedRequest != nil {
+				if timeouts.Request == nil {
+					t.Fatalf("Expected Request timeout to be set")
+				}
+				if *timeouts.Request != *tc.expectedRequest {
+					t.Errorf("Expected Request timeout %s, got %s", *tc.expectedRequest, *timeouts.Request)
+				}
+			}
+
+			if tc.expectedBackendRequest != nil {
+				if timeouts.BackendRequest == nil {
+					t.Fatalf("Expected BackendRequest timeout to be set")
+				}
+				if *timeouts.BackendRequest != *tc.expectedBackendRequest {
+					t.Errorf("Expected BackendRequest timeout %s, got %s", *tc.expectedBackendRequest, *timeouts.BackendRequest)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add support for nginx-ingress timeout annotations
- `proxy-read-timeout` maps to Gateway API `Request` timeout
- `proxy-connect-timeout` maps to Gateway API `BackendRequest` timeout
- Logs warnings for unsupported annotations (proxy-next-upstream, proxy-body-size, etc.)
- Includes Gateway API Duration format validation per GEP-2257

## Test plan
- [x] Added unit tests for `parseTimeoutValue` covering valid and invalid formats
- [x] Added unit tests for `timeoutFeature` feature parser
- [x] All existing tests pass
- [x] Manual verification of timeout annotation conversion

Fixes #270