### PR TITLE
feat(ingressnginx): implement backend TLS annotations support

### DIFF
--- a/pkg/i2gw/providers/ingressnginx/annotations.go
+++ b/pkg/i2gw/providers/ingressnginx/annotations.go
@@ -36,4 +36,13 @@ const (
 
 	// SSL Redirect annotation
 	SSLRedirectAnnotation = "nginx.ingress.kubernetes.io/ssl-redirect"
+
+	// Backend TLS annotations (proxy-ssl-*)
+	ProxySSLSecretAnnotation      = "nginx.ingress.kubernetes.io/proxy-ssl-secret"
+	ProxySSLCiphersAnnotation     = "nginx.ingress.kubernetes.io/proxy-ssl-ciphers"
+	ProxySSLNameAnnotation        = "nginx.ingress.kubernetes.io/proxy-ssl-name"
+	ProxySSLProtocolsAnnotation   = "nginx.ingress.kubernetes.io/proxy-ssl-protocols"
+	ProxySSLVerifyAnnotation      = "nginx.ingress.kubernetes.io/proxy-ssl-verify"
+	ProxySSLVerifyDepthAnnotation = "nginx.ingress.kubernetes.io/proxy-ssl-verify-depth"
+	ProxySSLServerNameAnnotation  = "nginx.ingress.kubernetes.io/proxy-ssl-server-name"
 )

--- a/pkg/i2gw/providers/ingressnginx/backend_tls.go
+++ b/pkg/i2gw/providers/ingressnginx/backend_tls.go
@@ -1,0 +1,307 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ingressnginx
+
+import (
+	"fmt"
+	"strings"
+
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw/notifications"
+	providerir "github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw/provider_intermediate"
+	"github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw/providers/common"
+)
+
+// backendTLSFeature processes backend TLS annotations (proxy-ssl-*) and creates
+// BackendTLSPolicy resources for services that require TLS connections to the backend.
+func backendTLSFeature(ingresses []networkingv1.Ingress, _ map[types.NamespacedName]map[string]int32, ir *providerir.ProviderIR) field.ErrorList {
+	var errs field.ErrorList
+
+	for _, ingress := range ingresses {
+		parseErrs := processBackendTLSAnnotations(&ingress, ir)
+		errs = append(errs, parseErrs...)
+	}
+
+	return errs
+}
+
+// processBackendTLSAnnotations processes the proxy-ssl-* annotations on an ingress
+// and creates BackendTLSPolicy resources as needed.
+func processBackendTLSAnnotations(ingress *networkingv1.Ingress, ir *providerir.ProviderIR) field.ErrorList {
+	var errs field.ErrorList
+
+	// Check if any backend TLS annotation is present
+	if !hasBackendTLSAnnotations(ingress) {
+		return nil
+	}
+
+	// Initialize BackendTLSPolicies map if needed
+	if ir.BackendTLSPolicies == nil {
+		ir.BackendTLSPolicies = make(map[types.NamespacedName]gatewayv1.BackendTLSPolicy)
+	}
+
+	// Collect all backend services from the ingress
+	services := collectBackendServices(ingress)
+	if len(services) == 0 {
+		return nil
+	}
+
+	// Parse the annotations
+	config, parseErrs := parseBackendTLSConfig(ingress)
+	if len(parseErrs) > 0 {
+		return parseErrs
+	}
+
+	// Warn about unsupported annotations
+	warnUnsupportedBackendTLSAnnotations(ingress, config)
+
+	// Create BackendTLSPolicy for each service
+	for serviceName := range services {
+		policy := createBackendTLSPolicy(ingress, serviceName, config)
+		policyKey := types.NamespacedName{
+			Namespace: ingress.Namespace,
+			Name:      policy.Name,
+		}
+
+		// Check for conflicting policies from different ingresses
+		if existingPolicy, exists := ir.BackendTLSPolicies[policyKey]; exists {
+			// Check if the configurations conflict
+			if existingPolicy.Spec.Validation.Hostname != policy.Spec.Validation.Hostname {
+				notify(notifications.WarningNotification,
+					fmt.Sprintf("BackendTLSPolicy %s already exists with different hostname (%s vs %s); using configuration from ingress %s/%s",
+						policyKey.Name,
+						existingPolicy.Spec.Validation.Hostname,
+						policy.Spec.Validation.Hostname,
+						ingress.Namespace, ingress.Name),
+					ingress)
+			}
+		}
+
+		ir.BackendTLSPolicies[policyKey] = policy
+	}
+
+	return errs
+}
+
+// backendTLSConfig holds the parsed values from backend TLS annotations.
+type backendTLSConfig struct {
+	// Secret containing client certificate (namespace/name format)
+	Secret string
+	// SecretNamespace is the namespace part of the secret reference
+	SecretNamespace string
+	// SecretName is the name part of the secret reference
+	SecretName string
+	// SSL ciphers to use
+	Ciphers string
+	// SNI hostname to use for backend connections
+	Name string
+	// SSL protocols to use
+	Protocols string
+	// Whether to verify backend certificate ("on" or "off")
+	Verify string
+	// Certificate verification depth
+	VerifyDepth string
+	// Whether to enable SNI ("on" or "off")
+	ServerName string
+}
+
+// hasBackendTLSAnnotations checks if the ingress has any backend TLS annotations.
+func hasBackendTLSAnnotations(ingress *networkingv1.Ingress) bool {
+	if ingress.Annotations == nil {
+		return false
+	}
+
+	annotations := []string{
+		ProxySSLSecretAnnotation,
+		ProxySSLCiphersAnnotation,
+		ProxySSLNameAnnotation,
+		ProxySSLProtocolsAnnotation,
+		ProxySSLVerifyAnnotation,
+		ProxySSLVerifyDepthAnnotation,
+		ProxySSLServerNameAnnotation,
+	}
+
+	for _, ann := range annotations {
+		if _, ok := ingress.Annotations[ann]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// parseBackendTLSConfig extracts backend TLS configuration from ingress annotations.
+func parseBackendTLSConfig(ingress *networkingv1.Ingress) (backendTLSConfig, field.ErrorList) {
+	var errs field.ErrorList
+
+	config := backendTLSConfig{
+		Secret:      ingress.Annotations[ProxySSLSecretAnnotation],
+		Ciphers:     ingress.Annotations[ProxySSLCiphersAnnotation],
+		Name:        ingress.Annotations[ProxySSLNameAnnotation],
+		Protocols:   ingress.Annotations[ProxySSLProtocolsAnnotation],
+		Verify:      ingress.Annotations[ProxySSLVerifyAnnotation],
+		VerifyDepth: ingress.Annotations[ProxySSLVerifyDepthAnnotation],
+		ServerName:  ingress.Annotations[ProxySSLServerNameAnnotation],
+	}
+
+	// Parse and validate secret reference if provided
+	if config.Secret != "" {
+		secretNamespace, secretName, err := parseSecretReference(config.Secret, ingress.Namespace)
+		if err != nil {
+			errs = append(errs, field.Invalid(
+				field.NewPath("ingress", ingress.Namespace, ingress.Name, "metadata", "annotations", ProxySSLSecretAnnotation),
+				config.Secret,
+				err.Error(),
+			))
+		} else {
+			config.SecretNamespace = secretNamespace
+			config.SecretName = secretName
+		}
+	}
+
+	return config, errs
+}
+
+// parseSecretReference parses a secret reference in the format "namespace/name" or "name".
+// Returns the namespace and name, using defaultNamespace if not specified.
+func parseSecretReference(ref, defaultNamespace string) (namespace, name string, err error) {
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return "", "", fmt.Errorf("empty secret reference")
+	}
+
+	parts := strings.SplitN(ref, "/", 2)
+	if len(parts) == 2 {
+		namespace = strings.TrimSpace(parts[0])
+		name = strings.TrimSpace(parts[1])
+		if namespace == "" {
+			return "", "", fmt.Errorf("empty namespace in secret reference %q", ref)
+		}
+		if name == "" {
+			return "", "", fmt.Errorf("empty name in secret reference %q", ref)
+		}
+	} else {
+		namespace = defaultNamespace
+		name = strings.TrimSpace(parts[0])
+		if name == "" {
+			return "", "", fmt.Errorf("empty secret name")
+		}
+	}
+
+	return namespace, name, nil
+}
+
+// collectBackendServices extracts all unique backend service names from an ingress.
+func collectBackendServices(ingress *networkingv1.Ingress) map[string]struct{} {
+	services := make(map[string]struct{})
+
+	// Check default backend
+	if ingress.Spec.DefaultBackend != nil && ingress.Spec.DefaultBackend.Service != nil {
+		services[ingress.Spec.DefaultBackend.Service.Name] = struct{}{}
+	}
+
+	// Check rule backends
+	for _, rule := range ingress.Spec.Rules {
+		if rule.HTTP == nil {
+			continue
+		}
+		for _, path := range rule.HTTP.Paths {
+			if path.Backend.Service != nil {
+				services[path.Backend.Service.Name] = struct{}{}
+			}
+		}
+	}
+
+	return services
+}
+
+// warnUnsupportedBackendTLSAnnotations emits warnings for annotations that cannot
+// be fully converted to Gateway API BackendTLSPolicy.
+func warnUnsupportedBackendTLSAnnotations(ingress *networkingv1.Ingress, config backendTLSConfig) {
+	var warnings []string
+
+	if config.Ciphers != "" {
+		warnings = append(warnings, fmt.Sprintf("%s: SSL cipher configuration is not supported by Gateway API BackendTLSPolicy", ProxySSLCiphersAnnotation))
+	}
+
+	if config.Protocols != "" {
+		warnings = append(warnings, fmt.Sprintf("%s: SSL protocol configuration is not supported by Gateway API BackendTLSPolicy", ProxySSLProtocolsAnnotation))
+	}
+
+	if config.VerifyDepth != "" {
+		warnings = append(warnings, fmt.Sprintf("%s: certificate verification depth is not supported by Gateway API BackendTLSPolicy", ProxySSLVerifyDepthAnnotation))
+	}
+
+	if config.ServerName != "" {
+		warnings = append(warnings, fmt.Sprintf("%s: server name (SNI) on/off toggle is not supported; SNI is always used when hostname is set", ProxySSLServerNameAnnotation))
+	}
+
+	if config.Secret != "" {
+		warnings = append(warnings, fmt.Sprintf("%s: client certificate (mTLS to backend) requires manual configuration of BackendTLSPolicy.Spec.Options or implementation-specific extensions", ProxySSLSecretAnnotation))
+	}
+
+	if config.Verify == "on" || config.Verify == "true" {
+		warnings = append(warnings, fmt.Sprintf("%s: backend certificate verification enabled; you must manually configure BackendTLSPolicy.Spec.Validation with appropriate CA certificates", ProxySSLVerifyAnnotation))
+	}
+
+	for _, warning := range warnings {
+		notify(notifications.WarningNotification, warning, ingress)
+	}
+}
+
+// createBackendTLSPolicy creates a BackendTLSPolicy for a specific service.
+// Uses common.CreateBackendTLSPolicy as base and adds hostname configuration.
+func createBackendTLSPolicy(ingress *networkingv1.Ingress, serviceName string, config backendTLSConfig) gatewayv1.BackendTLSPolicy {
+	policyName := fmt.Sprintf("%s-%s-backend-tls", ingress.Name, serviceName)
+
+	// Use the common helper to create the base policy
+	policy := common.CreateBackendTLSPolicy(ingress.Namespace, policyName, serviceName)
+
+	// Set hostname for SNI validation
+	// If proxy-ssl-name is provided, use it; otherwise use the service name as a sensible default
+	if config.Name != "" {
+		policy.Spec.Validation.Hostname = gatewayv1.PreciseHostname(config.Name)
+	} else {
+		// Use service name as default hostname for validation
+		// This ensures the BackendTLSPolicy has a valid Hostname field
+		policy.Spec.Validation.Hostname = gatewayv1.PreciseHostname(serviceName)
+		notify(notifications.InfoNotification,
+			fmt.Sprintf("BackendTLSPolicy for service %s: using service name as default hostname; set %s to specify custom SNI hostname",
+				serviceName, ProxySSLNameAnnotation),
+			ingress)
+	}
+
+	// If verify is disabled, warn about Gateway API limitations
+	if config.Verify == "off" || config.Verify == "false" {
+		notify(notifications.WarningNotification,
+			fmt.Sprintf("%s=off: Gateway API BackendTLSPolicy does not support disabling certificate verification; backend TLS will require valid certificates", ProxySSLVerifyAnnotation),
+			ingress)
+	}
+
+	// Add info notification about secret reference if provided
+	if config.SecretName != "" {
+		notify(notifications.InfoNotification,
+			fmt.Sprintf("BackendTLSPolicy created for service %s; client certificate from secret (namespace=%s, name=%s) requires manual configuration",
+				serviceName, config.SecretNamespace, config.SecretName),
+			ingress)
+	}
+
+	return policy
+}

--- a/pkg/i2gw/providers/ingressnginx/backend_tls_test.go
+++ b/pkg/i2gw/providers/ingressnginx/backend_tls_test.go
@@ -1,0 +1,741 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ingressnginx
+
+import (
+	"testing"
+
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	providerir "github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw/provider_intermediate"
+)
+
+func TestHasBackendTLSAnnotations(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		expected    bool
+	}{
+		{
+			name:        "nil annotations",
+			annotations: nil,
+			expected:    false,
+		},
+		{
+			name:        "no annotations",
+			annotations: map[string]string{},
+			expected:    false,
+		},
+		{
+			name: "unrelated annotations",
+			annotations: map[string]string{
+				"nginx.ingress.kubernetes.io/rewrite-target": "/",
+			},
+			expected: false,
+		},
+		{
+			name: "proxy-ssl-secret annotation",
+			annotations: map[string]string{
+				ProxySSLSecretAnnotation: "default/my-cert",
+			},
+			expected: true,
+		},
+		{
+			name: "proxy-ssl-name annotation",
+			annotations: map[string]string{
+				ProxySSLNameAnnotation: "backend.example.com",
+			},
+			expected: true,
+		},
+		{
+			name: "proxy-ssl-verify annotation",
+			annotations: map[string]string{
+				ProxySSLVerifyAnnotation: "on",
+			},
+			expected: true,
+		},
+		{
+			name: "multiple backend TLS annotations",
+			annotations: map[string]string{
+				ProxySSLSecretAnnotation:    "default/my-cert",
+				ProxySSLNameAnnotation:      "backend.example.com",
+				ProxySSLVerifyAnnotation:    "on",
+				ProxySSLProtocolsAnnotation: "TLSv1.2 TLSv1.3",
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ingress := &networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: tt.annotations,
+				},
+			}
+			result := hasBackendTLSAnnotations(ingress)
+			if result != tt.expected {
+				t.Errorf("hasBackendTLSAnnotations() = %v, expected %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestParseSecretReference(t *testing.T) {
+	tests := []struct {
+		name              string
+		ref               string
+		defaultNamespace  string
+		expectedNamespace string
+		expectedName      string
+		expectError       bool
+	}{
+		{
+			name:              "namespace/name format",
+			ref:               "my-namespace/my-secret",
+			defaultNamespace:  "default",
+			expectedNamespace: "my-namespace",
+			expectedName:      "my-secret",
+			expectError:       false,
+		},
+		{
+			name:              "name only format",
+			ref:               "my-secret",
+			defaultNamespace:  "default",
+			expectedNamespace: "default",
+			expectedName:      "my-secret",
+			expectError:       false,
+		},
+		{
+			name:              "with spaces trimmed",
+			ref:               "  my-namespace / my-secret  ",
+			defaultNamespace:  "default",
+			expectedNamespace: "my-namespace",
+			expectedName:      "my-secret",
+			expectError:       false,
+		},
+		{
+			name:             "empty reference",
+			ref:              "",
+			defaultNamespace: "default",
+			expectError:      true,
+		},
+		{
+			name:             "empty reference with spaces",
+			ref:              "   ",
+			defaultNamespace: "default",
+			expectError:      true,
+		},
+		{
+			name:             "empty namespace",
+			ref:              "/my-secret",
+			defaultNamespace: "default",
+			expectError:      true,
+		},
+		{
+			name:             "empty name",
+			ref:              "my-namespace/",
+			defaultNamespace: "default",
+			expectError:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			namespace, name, err := parseSecretReference(tt.ref, tt.defaultNamespace)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			if namespace != tt.expectedNamespace {
+				t.Errorf("namespace = %q, expected %q", namespace, tt.expectedNamespace)
+			}
+			if name != tt.expectedName {
+				t.Errorf("name = %q, expected %q", name, tt.expectedName)
+			}
+		})
+	}
+}
+
+func TestParseBackendTLSConfig(t *testing.T) {
+	t.Run("valid config with all annotations", func(t *testing.T) {
+		ingress := &networkingv1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Annotations: map[string]string{
+					ProxySSLSecretAnnotation:      "other-ns/my-cert",
+					ProxySSLCiphersAnnotation:     "HIGH:!aNULL:!MD5",
+					ProxySSLNameAnnotation:        "backend.example.com",
+					ProxySSLProtocolsAnnotation:   "TLSv1.2 TLSv1.3",
+					ProxySSLVerifyAnnotation:      "on",
+					ProxySSLVerifyDepthAnnotation: "2",
+					ProxySSLServerNameAnnotation:  "on",
+				},
+			},
+		}
+
+		config, errs := parseBackendTLSConfig(ingress)
+
+		if len(errs) > 0 {
+			t.Errorf("unexpected errors: %v", errs)
+		}
+
+		if config.Secret != "other-ns/my-cert" {
+			t.Errorf("Secret = %q, expected %q", config.Secret, "other-ns/my-cert")
+		}
+		if config.SecretNamespace != "other-ns" {
+			t.Errorf("SecretNamespace = %q, expected %q", config.SecretNamespace, "other-ns")
+		}
+		if config.SecretName != "my-cert" {
+			t.Errorf("SecretName = %q, expected %q", config.SecretName, "my-cert")
+		}
+		if config.Ciphers != "HIGH:!aNULL:!MD5" {
+			t.Errorf("Ciphers = %q, expected %q", config.Ciphers, "HIGH:!aNULL:!MD5")
+		}
+		if config.Name != "backend.example.com" {
+			t.Errorf("Name = %q, expected %q", config.Name, "backend.example.com")
+		}
+		if config.Protocols != "TLSv1.2 TLSv1.3" {
+			t.Errorf("Protocols = %q, expected %q", config.Protocols, "TLSv1.2 TLSv1.3")
+		}
+		if config.Verify != "on" {
+			t.Errorf("Verify = %q, expected %q", config.Verify, "on")
+		}
+		if config.VerifyDepth != "2" {
+			t.Errorf("VerifyDepth = %q, expected %q", config.VerifyDepth, "2")
+		}
+		if config.ServerName != "on" {
+			t.Errorf("ServerName = %q, expected %q", config.ServerName, "on")
+		}
+	})
+
+	t.Run("secret without namespace uses ingress namespace", func(t *testing.T) {
+		ingress := &networkingv1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "my-namespace",
+				Annotations: map[string]string{
+					ProxySSLSecretAnnotation: "my-cert",
+				},
+			},
+		}
+
+		config, errs := parseBackendTLSConfig(ingress)
+
+		if len(errs) > 0 {
+			t.Errorf("unexpected errors: %v", errs)
+		}
+
+		if config.SecretNamespace != "my-namespace" {
+			t.Errorf("SecretNamespace = %q, expected %q", config.SecretNamespace, "my-namespace")
+		}
+		if config.SecretName != "my-cert" {
+			t.Errorf("SecretName = %q, expected %q", config.SecretName, "my-cert")
+		}
+	})
+
+	t.Run("invalid secret reference returns error", func(t *testing.T) {
+		ingress := &networkingv1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      "test-ingress",
+				Annotations: map[string]string{
+					ProxySSLSecretAnnotation: "/invalid",
+				},
+			},
+		}
+
+		_, errs := parseBackendTLSConfig(ingress)
+
+		if len(errs) == 0 {
+			t.Error("expected error for invalid secret reference")
+		}
+	})
+}
+
+func TestCollectBackendServices(t *testing.T) {
+	pathType := networkingv1.PathTypePrefix
+	ingress := &networkingv1.Ingress{
+		Spec: networkingv1.IngressSpec{
+			DefaultBackend: &networkingv1.IngressBackend{
+				Service: &networkingv1.IngressServiceBackend{
+					Name: "default-svc",
+					Port: networkingv1.ServiceBackendPort{Number: 80},
+				},
+			},
+			Rules: []networkingv1.IngressRule{
+				{
+					Host: "example.com",
+					IngressRuleValue: networkingv1.IngressRuleValue{
+						HTTP: &networkingv1.HTTPIngressRuleValue{
+							Paths: []networkingv1.HTTPIngressPath{
+								{
+									Path:     "/api",
+									PathType: &pathType,
+									Backend: networkingv1.IngressBackend{
+										Service: &networkingv1.IngressServiceBackend{
+											Name: "api-svc",
+											Port: networkingv1.ServiceBackendPort{Number: 8080},
+										},
+									},
+								},
+								{
+									Path:     "/web",
+									PathType: &pathType,
+									Backend: networkingv1.IngressBackend{
+										Service: &networkingv1.IngressServiceBackend{
+											Name: "web-svc",
+											Port: networkingv1.ServiceBackendPort{Number: 8080},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	services := collectBackendServices(ingress)
+
+	expectedServices := []string{"default-svc", "api-svc", "web-svc"}
+	if len(services) != len(expectedServices) {
+		t.Errorf("Expected %d services, got %d", len(expectedServices), len(services))
+	}
+
+	for _, svc := range expectedServices {
+		if _, ok := services[svc]; !ok {
+			t.Errorf("Expected service %q not found", svc)
+		}
+	}
+}
+
+func TestCreateBackendTLSPolicy(t *testing.T) {
+	ingress := &networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-ingress",
+			Namespace: "default",
+		},
+	}
+
+	tests := []struct {
+		name            string
+		serviceName     string
+		config          backendTLSConfig
+		expectedName    string
+		expectedHost    gatewayv1.PreciseHostname
+	}{
+		{
+			name:            "policy without explicit hostname uses service name",
+			serviceName:     "my-service",
+			config:          backendTLSConfig{},
+			expectedName:    "my-ingress-my-service-backend-tls",
+			expectedHost:    "my-service",
+		},
+		{
+			name:         "policy with explicit hostname",
+			serviceName:  "api-service",
+			config:       backendTLSConfig{Name: "api.backend.local"},
+			expectedName: "my-ingress-api-service-backend-tls",
+			expectedHost: "api.backend.local",
+		},
+		{
+			name:        "policy with secret reference",
+			serviceName: "secure-service",
+			config: backendTLSConfig{
+				SecretNamespace: "default",
+				SecretName:      "client-cert",
+				Name:            "secure.backend.local",
+			},
+			expectedName: "my-ingress-secure-service-backend-tls",
+			expectedHost: "secure.backend.local",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			policy := createBackendTLSPolicy(ingress, tt.serviceName, tt.config)
+
+			if policy.Name != tt.expectedName {
+				t.Errorf("Policy name = %q, expected %q", policy.Name, tt.expectedName)
+			}
+
+			if policy.Namespace != ingress.Namespace {
+				t.Errorf("Policy namespace = %q, expected %q", policy.Namespace, ingress.Namespace)
+			}
+
+			if policy.Kind != "BackendTLSPolicy" {
+				t.Errorf("Policy kind = %q, expected %q", policy.Kind, "BackendTLSPolicy")
+			}
+
+			if len(policy.Spec.TargetRefs) != 1 {
+				t.Fatalf("Expected 1 target ref, got %d", len(policy.Spec.TargetRefs))
+			}
+
+			targetRef := policy.Spec.TargetRefs[0]
+			if string(targetRef.Name) != tt.serviceName {
+				t.Errorf("TargetRef name = %q, expected %q", targetRef.Name, tt.serviceName)
+			}
+			if targetRef.Kind != "Service" {
+				t.Errorf("TargetRef kind = %q, expected %q", targetRef.Kind, "Service")
+			}
+
+			if policy.Spec.Validation.Hostname != tt.expectedHost {
+				t.Errorf("Hostname = %q, expected %q", policy.Spec.Validation.Hostname, tt.expectedHost)
+			}
+		})
+	}
+}
+
+func TestBackendTLSFeature(t *testing.T) {
+	pathType := networkingv1.PathTypePrefix
+
+	tests := []struct {
+		name              string
+		ingresses         []networkingv1.Ingress
+		expectedPolicies  int
+		expectedPolicyKey types.NamespacedName
+	}{
+		{
+			name: "ingress without backend TLS annotations",
+			ingresses: []networkingv1.Ingress{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "basic-ingress",
+						Namespace:   "default",
+						Annotations: map[string]string{},
+					},
+					Spec: networkingv1.IngressSpec{
+						Rules: []networkingv1.IngressRule{
+							{
+								Host: "example.com",
+								IngressRuleValue: networkingv1.IngressRuleValue{
+									HTTP: &networkingv1.HTTPIngressRuleValue{
+										Paths: []networkingv1.HTTPIngressPath{
+											{
+												Path:     "/",
+												PathType: &pathType,
+												Backend: networkingv1.IngressBackend{
+													Service: &networkingv1.IngressServiceBackend{
+														Name: "my-service",
+														Port: networkingv1.ServiceBackendPort{Number: 80},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedPolicies: 0,
+		},
+		{
+			name: "ingress with proxy-ssl-name annotation",
+			ingresses: []networkingv1.Ingress{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "tls-ingress",
+						Namespace: "default",
+						Annotations: map[string]string{
+							ProxySSLNameAnnotation: "backend.example.com",
+						},
+					},
+					Spec: networkingv1.IngressSpec{
+						Rules: []networkingv1.IngressRule{
+							{
+								Host: "example.com",
+								IngressRuleValue: networkingv1.IngressRuleValue{
+									HTTP: &networkingv1.HTTPIngressRuleValue{
+										Paths: []networkingv1.HTTPIngressPath{
+											{
+												Path:     "/",
+												PathType: &pathType,
+												Backend: networkingv1.IngressBackend{
+													Service: &networkingv1.IngressServiceBackend{
+														Name: "backend-service",
+														Port: networkingv1.ServiceBackendPort{Number: 443},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedPolicies:  1,
+			expectedPolicyKey: types.NamespacedName{Namespace: "default", Name: "tls-ingress-backend-service-backend-tls"},
+		},
+		{
+			name: "ingress with multiple services and backend TLS",
+			ingresses: []networkingv1.Ingress{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "multi-svc-ingress",
+						Namespace: "production",
+						Annotations: map[string]string{
+							ProxySSLVerifyAnnotation: "on",
+							ProxySSLNameAnnotation:   "internal.cluster.local",
+						},
+					},
+					Spec: networkingv1.IngressSpec{
+						Rules: []networkingv1.IngressRule{
+							{
+								Host: "api.example.com",
+								IngressRuleValue: networkingv1.IngressRuleValue{
+									HTTP: &networkingv1.HTTPIngressRuleValue{
+										Paths: []networkingv1.HTTPIngressPath{
+											{
+												Path:     "/v1",
+												PathType: &pathType,
+												Backend: networkingv1.IngressBackend{
+													Service: &networkingv1.IngressServiceBackend{
+														Name: "api-v1",
+														Port: networkingv1.ServiceBackendPort{Number: 443},
+													},
+												},
+											},
+											{
+												Path:     "/v2",
+												PathType: &pathType,
+												Backend: networkingv1.IngressBackend{
+													Service: &networkingv1.IngressServiceBackend{
+														Name: "api-v2",
+														Port: networkingv1.ServiceBackendPort{Number: 443},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedPolicies: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ir := &providerir.ProviderIR{
+				HTTPRoutes: make(map[types.NamespacedName]providerir.HTTPRouteContext),
+			}
+
+			errs := backendTLSFeature(tt.ingresses, nil, ir)
+			if len(errs) > 0 {
+				t.Fatalf("Unexpected errors: %v", errs)
+			}
+
+			if ir.BackendTLSPolicies == nil && tt.expectedPolicies > 0 {
+				t.Fatalf("Expected BackendTLSPolicies map to be initialized")
+			}
+
+			if tt.expectedPolicies > 0 {
+				if len(ir.BackendTLSPolicies) != tt.expectedPolicies {
+					t.Errorf("Expected %d policies, got %d", tt.expectedPolicies, len(ir.BackendTLSPolicies))
+				}
+			}
+
+			if tt.expectedPolicyKey.Name != "" {
+				if _, ok := ir.BackendTLSPolicies[tt.expectedPolicyKey]; !ok {
+					t.Errorf("Expected policy %v not found", tt.expectedPolicyKey)
+				}
+			}
+		})
+	}
+}
+
+func TestBackendTLSFeature_PolicyHostname(t *testing.T) {
+	pathType := networkingv1.PathTypePrefix
+	ingresses := []networkingv1.Ingress{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-ingress",
+				Namespace: "default",
+				Annotations: map[string]string{
+					ProxySSLNameAnnotation: "secure-backend.internal",
+				},
+			},
+			Spec: networkingv1.IngressSpec{
+				Rules: []networkingv1.IngressRule{
+					{
+						Host: "example.com",
+						IngressRuleValue: networkingv1.IngressRuleValue{
+							HTTP: &networkingv1.HTTPIngressRuleValue{
+								Paths: []networkingv1.HTTPIngressPath{
+									{
+										Path:     "/",
+										PathType: &pathType,
+										Backend: networkingv1.IngressBackend{
+											Service: &networkingv1.IngressServiceBackend{
+												Name: "my-service",
+												Port: networkingv1.ServiceBackendPort{Number: 443},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ir := &providerir.ProviderIR{
+		HTTPRoutes: make(map[types.NamespacedName]providerir.HTTPRouteContext),
+	}
+
+	errs := backendTLSFeature(ingresses, nil, ir)
+	if len(errs) > 0 {
+		t.Fatalf("Unexpected errors: %v", errs)
+	}
+
+	policyKey := types.NamespacedName{Namespace: "default", Name: "test-ingress-my-service-backend-tls"}
+	policy, ok := ir.BackendTLSPolicies[policyKey]
+	if !ok {
+		t.Fatalf("Expected policy %v not found", policyKey)
+	}
+
+	if policy.Spec.Validation.Hostname != "secure-backend.internal" {
+		t.Errorf("Policy hostname = %q, expected %q", policy.Spec.Validation.Hostname, "secure-backend.internal")
+	}
+}
+
+func TestBackendTLSFeature_DefaultHostname(t *testing.T) {
+	pathType := networkingv1.PathTypePrefix
+	ingresses := []networkingv1.Ingress{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-ingress",
+				Namespace: "default",
+				Annotations: map[string]string{
+					ProxySSLVerifyAnnotation: "on", // Triggers backend TLS but no explicit hostname
+				},
+			},
+			Spec: networkingv1.IngressSpec{
+				Rules: []networkingv1.IngressRule{
+					{
+						Host: "example.com",
+						IngressRuleValue: networkingv1.IngressRuleValue{
+							HTTP: &networkingv1.HTTPIngressRuleValue{
+								Paths: []networkingv1.HTTPIngressPath{
+									{
+										Path:     "/",
+										PathType: &pathType,
+										Backend: networkingv1.IngressBackend{
+											Service: &networkingv1.IngressServiceBackend{
+												Name: "backend-svc",
+												Port: networkingv1.ServiceBackendPort{Number: 443},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ir := &providerir.ProviderIR{
+		HTTPRoutes: make(map[types.NamespacedName]providerir.HTTPRouteContext),
+	}
+
+	errs := backendTLSFeature(ingresses, nil, ir)
+	if len(errs) > 0 {
+		t.Fatalf("Unexpected errors: %v", errs)
+	}
+
+	policyKey := types.NamespacedName{Namespace: "default", Name: "test-ingress-backend-svc-backend-tls"}
+	policy, ok := ir.BackendTLSPolicies[policyKey]
+	if !ok {
+		t.Fatalf("Expected policy %v not found", policyKey)
+	}
+
+	// Should use service name as default hostname
+	if policy.Spec.Validation.Hostname != "backend-svc" {
+		t.Errorf("Policy hostname = %q, expected %q (service name as default)", policy.Spec.Validation.Hostname, "backend-svc")
+	}
+}
+
+func TestBackendTLSFeature_InvalidSecretReference(t *testing.T) {
+	pathType := networkingv1.PathTypePrefix
+	ingresses := []networkingv1.Ingress{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-ingress",
+				Namespace: "default",
+				Annotations: map[string]string{
+					ProxySSLSecretAnnotation: "/invalid-secret",
+				},
+			},
+			Spec: networkingv1.IngressSpec{
+				Rules: []networkingv1.IngressRule{
+					{
+						Host: "example.com",
+						IngressRuleValue: networkingv1.IngressRuleValue{
+							HTTP: &networkingv1.HTTPIngressRuleValue{
+								Paths: []networkingv1.HTTPIngressPath{
+									{
+										Path:     "/",
+										PathType: &pathType,
+										Backend: networkingv1.IngressBackend{
+											Service: &networkingv1.IngressServiceBackend{
+												Name: "my-service",
+												Port: networkingv1.ServiceBackendPort{Number: 443},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ir := &providerir.ProviderIR{
+		HTTPRoutes: make(map[types.NamespacedName]providerir.HTTPRouteContext),
+	}
+
+	errs := backendTLSFeature(ingresses, nil, ir)
+	if len(errs) == 0 {
+		t.Error("Expected error for invalid secret reference")
+	}
+}

--- a/pkg/i2gw/providers/ingressnginx/converter.go
+++ b/pkg/i2gw/providers/ingressnginx/converter.go
@@ -34,6 +34,7 @@ func newResourcesToIRConverter() *resourcesToIRConverter {
 		featureParsers: []i2gw.FeatureParser{
 			canaryFeature,
 			headerModifierFeature,
+			backendTLSFeature,
 		},
 	}
 }


### PR DESCRIPTION
## Summary

Adds support for ingress-nginx `proxy-ssl-*` annotations by creating `BackendTLSPolicy` resources for services that require TLS connections to the backend.

- Implements support for all 7 backend TLS annotations from issue #269
- Maps `proxy-ssl-name` to `BackendTLSPolicy.Spec.Validation.Hostname`
- Uses service name as default hostname when `proxy-ssl-name` is not specified
- Emits warnings for annotations without direct Gateway API equivalents (ciphers, protocols, verify-depth)
- Uses `common.CreateBackendTLSPolicy` helper for consistency with nginx provider
- Validates secret references and returns errors for invalid formats
- Detects and warns about conflicting policies from multiple ingresses

**Supported annotations:**
- `nginx.ingress.kubernetes.io/proxy-ssl-secret`
- `nginx.ingress.kubernetes.io/proxy-ssl-ciphers`
- `nginx.ingress.kubernetes.io/proxy-ssl-name`
- `nginx.ingress.kubernetes.io/proxy-ssl-protocols`
- `nginx.ingress.kubernetes.io/proxy-ssl-verify`
- `nginx.ingress.kubernetes.io/proxy-ssl-verify-depth`
- `nginx.ingress.kubernetes.io/proxy-ssl-server-name`

## Test plan

- [x] Added unit tests for `hasBackendTLSAnnotations` (including nil annotations)
- [x] Added unit tests for `parseSecretReference` (7 test cases including edge cases)
- [x] Added unit tests for `parseBackendTLSConfig` (valid config, default namespace, invalid reference)
- [x] Added unit tests for `collectBackendServices`
- [x] Added unit tests for `createBackendTLSPolicy` (default hostname, explicit hostname, with secret)
- [x] Added unit tests for `backendTLSFeature` (no annotations, single service, multiple services)
- [x] Added unit tests for default hostname behavior
- [x] Added unit tests for invalid secret reference error handling
- [x] All existing tests pass

Fixes #269