### PR TITLE
feat: add gcp affinity annotation parsing

### DIFF
--- a/pkg/i2gw/emitter_intermediate/gce/gce.go
+++ b/pkg/i2gw/emitter_intermediate/gce/gce.go
@@ -25,13 +25,8 @@ type SslPolicyConfig struct {
 }
 type HTTPRouteIR struct{}
 type ServiceIR struct {
-	SessionAffinity *SessionAffinityConfig
-	SecurityPolicy  *SecurityPolicyConfig
-	HealthCheck     *HealthCheckConfig
-}
-type SessionAffinityConfig struct {
-	AffinityType string
-	CookieTTLSec *int64
+	SecurityPolicy *SecurityPolicyConfig
+	HealthCheck    *HealthCheckConfig
 }
 type SecurityPolicyConfig struct {
 	Name string

--- a/pkg/i2gw/emitter_intermediate/intermediate_representation.go
+++ b/pkg/i2gw/emitter_intermediate/intermediate_representation.go
@@ -43,6 +43,16 @@ type EmitterIR struct {
 	ReferenceGrants    map[types.NamespacedName]ReferenceGrantContext
 
 	GceServices map[types.NamespacedName]gce.ServiceIR
+	Services    map[types.NamespacedName]ServiceContext
+}
+
+type ServiceContext struct {
+	SessionAffinity *SessionAffinityConfig
+}
+
+type SessionAffinityConfig struct {
+	AffinityType string
+	CookieTTLSec *int64
 }
 
 type GatewayContext struct {

--- a/pkg/i2gw/emitters/gce/gce_test.go
+++ b/pkg/i2gw/emitters/gce/gce_test.go
@@ -239,9 +239,9 @@ func Test_irToGateway(t *testing.T) {
 						HTTPRoute: testHTTPRoute,
 					},
 				},
-				GceServices: map[types.NamespacedName]gce.ServiceIR{
+				Services: map[types.NamespacedName]emitterir.ServiceContext{
 					{Namespace: testNamespace, Name: testServiceName}: {
-						SessionAffinity: &gce.SessionAffinityConfig{
+						SessionAffinity: &emitterir.SessionAffinityConfig{
 							AffinityType: saTypeClientIP,
 						},
 					},
@@ -273,9 +273,9 @@ func Test_irToGateway(t *testing.T) {
 						HTTPRoute: testHTTPRoute,
 					},
 				},
-				GceServices: map[types.NamespacedName]gce.ServiceIR{
+				Services: map[types.NamespacedName]emitterir.ServiceContext{
 					{Namespace: testNamespace, Name: testServiceName}: {
-						SessionAffinity: &gce.SessionAffinityConfig{
+						SessionAffinity: &emitterir.SessionAffinityConfig{
 							AffinityType: saTypeCookie,
 							CookieTTLSec: common.PtrTo(testCookieTTLSec),
 						},

--- a/pkg/i2gw/emitters/gce/output_extensions.go
+++ b/pkg/i2gw/emitters/gce/output_extensions.go
@@ -22,13 +22,13 @@ import (
 	"github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw/emitter_intermediate/gce"
 )
 
-func BuildGCPBackendPolicySessionAffinityConfig(gceServiceIR gce.ServiceIR) *gkegatewayv1.SessionAffinityConfig {
-	affinityType := gceServiceIR.SessionAffinity.AffinityType
+func BuildGCPBackendPolicySessionAffinityConfig(sessionAffinity *emitterir.SessionAffinityConfig) *gkegatewayv1.SessionAffinityConfig {
+	affinityType := sessionAffinity.AffinityType
 	saConfig := gkegatewayv1.SessionAffinityConfig{
 		Type: &affinityType,
 	}
 	if affinityType == "GENERATED_COOKIE" {
-		saConfig.CookieTTLSec = gceServiceIR.SessionAffinity.CookieTTLSec
+		saConfig.CookieTTLSec = sessionAffinity.CookieTTLSec
 	}
 	return &saConfig
 }

--- a/pkg/i2gw/provider_intermediate/conversion.go
+++ b/pkg/i2gw/provider_intermediate/conversion.go
@@ -18,6 +18,7 @@ package providerir
 
 import (
 	emitterir "github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw/emitter_intermediate"
+	"github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw/emitter_intermediate/gce"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -60,6 +61,13 @@ func ToEmitterIR(pIR ProviderIR) emitterir.EmitterIR {
 	}
 	for k, v := range pIR.ReferenceGrants {
 		eIR.ReferenceGrants[k] = emitterir.ReferenceGrantContext{ReferenceGrant: v}
+	}
+
+	eIR.GceServices = make(map[types.NamespacedName]gce.ServiceIR)
+	for k, v := range pIR.Services {
+		if v.Gce != nil {
+			eIR.GceServices[k] = *v.Gce
+		}
 	}
 
 	return eIR

--- a/pkg/i2gw/provider_intermediate/conversion.go
+++ b/pkg/i2gw/provider_intermediate/conversion.go
@@ -64,9 +64,18 @@ func ToEmitterIR(pIR ProviderIR) emitterir.EmitterIR {
 	}
 
 	eIR.GceServices = make(map[types.NamespacedName]gce.ServiceIR)
+	eIR.Services = make(map[types.NamespacedName]emitterir.ServiceContext)
 	for k, v := range pIR.Services {
-		if v.Gce != nil {
-			eIR.GceServices[k] = *v.Gce
+		if v.ProviderSpecificIR.Gce != nil {
+			eIR.GceServices[k] = *v.ProviderSpecificIR.Gce
+		}
+		if v.SessionAffinity != nil {
+			eIR.Services[k] = emitterir.ServiceContext{
+				SessionAffinity: &emitterir.SessionAffinityConfig{
+					AffinityType: v.SessionAffinity.AffinityType,
+					CookieTTLSec: v.SessionAffinity.CookieTTLSec,
+				},
+			}
 		}
 	}
 

--- a/pkg/i2gw/provider_intermediate/intermediate_representation.go
+++ b/pkg/i2gw/provider_intermediate/intermediate_representation.go
@@ -32,7 +32,7 @@ import (
 type ProviderIR struct {
 	Gateways   map[types.NamespacedName]GatewayContext
 	HTTPRoutes map[types.NamespacedName]HTTPRouteContext
-	Services   map[types.NamespacedName]ProviderSpecificServiceIR
+	Services   map[types.NamespacedName]ServiceContext
 
 	GatewayClasses map[types.NamespacedName]gatewayv1.GatewayClass
 	TLSRoutes      map[types.NamespacedName]gatewayv1alpha2.TLSRoute
@@ -79,6 +79,19 @@ type ProviderSpecificHTTPRouteIR struct {
 // extension features on Service.
 type ProviderSpecificServiceIR struct {
 	Gce *gce.ServiceIR
+}
+
+// ServiceContext contains the Gateway-API Service object and ServiceIR, which
+// has a dedicated field for each provider to specify their extension features
+// on Service.
+type ServiceContext struct {
+	ProviderSpecificIR ProviderSpecificServiceIR
+	SessionAffinity    *SessionAffinityConfig
+}
+
+type SessionAffinityConfig struct {
+	AffinityType string
+	CookieTTLSec *int64
 }
 
 // BackendSource tracks the source Ingress resource that contributed

--- a/pkg/i2gw/providers/common/converter.go
+++ b/pkg/i2gw/providers/common/converter.go
@@ -74,7 +74,7 @@ func ToIR(ingresses []networkingv1.Ingress, servicePorts map[types.NamespacedNam
 	return providerir.ProviderIR{
 		Gateways:           gatewayByKey,
 		HTTPRoutes:         routeByKey,
-		Services:           make(map[types.NamespacedName]providerir.ProviderSpecificServiceIR),
+		Services:           make(map[types.NamespacedName]providerir.ServiceContext),
 		GatewayClasses:     make(map[types.NamespacedName]gatewayv1.GatewayClass),
 		TLSRoutes:          make(map[types.NamespacedName]gatewayv1alpha2.TLSRoute),
 		TCPRoutes:          make(map[types.NamespacedName]gatewayv1alpha2.TCPRoute),

--- a/pkg/i2gw/providers/gce/extensions/input_extensions.go
+++ b/pkg/i2gw/providers/gce/extensions/input_extensions.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw/emitter_intermediate/gce"
+	providerir "github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw/provider_intermediate"
 	"k8s.io/apimachinery/pkg/util/sets"
 	backendconfigv1 "k8s.io/ingress-gce/pkg/apis/backendconfig/v1"
 	frontendconfigv1beta1 "k8s.io/ingress-gce/pkg/apis/frontendconfig/v1beta1"
@@ -60,8 +61,8 @@ func validateHealthCheck(beConfig *backendconfigv1.BackendConfig) error {
 	return nil
 }
 
-func BuildIRSessionAffinityConfig(beConfig *backendconfigv1.BackendConfig) *gce.SessionAffinityConfig {
-	return &gce.SessionAffinityConfig{
+func BuildIRSessionAffinityConfig(beConfig *backendconfigv1.BackendConfig) *providerir.SessionAffinityConfig {
+	return &providerir.SessionAffinityConfig{
 		AffinityType: beConfig.Spec.SessionAffinity.AffinityType,
 		CookieTTLSec: beConfig.Spec.SessionAffinity.AffinityCookieTtlSec,
 	}

--- a/pkg/i2gw/providers/gce/ir_converter_test.go
+++ b/pkg/i2gw/providers/gce/ir_converter_test.go
@@ -541,12 +541,10 @@ func Test_convertToIR(t *testing.T) {
 						},
 					},
 				},
-				Services: map[types.NamespacedName]providerir.ProviderSpecificServiceIR{
+				Services: map[types.NamespacedName]providerir.ServiceContext{
 					{Namespace: testNamespace, Name: testServiceName}: {
-						Gce: &gce.ServiceIR{
-							SessionAffinity: &gce.SessionAffinityConfig{
-								AffinityType: saTypeClientIP,
-							},
+						SessionAffinity: &providerir.SessionAffinityConfig{
+							AffinityType: saTypeClientIP,
 						},
 					},
 				},
@@ -627,13 +625,11 @@ func Test_convertToIR(t *testing.T) {
 						},
 					},
 				},
-				Services: map[types.NamespacedName]providerir.ProviderSpecificServiceIR{
+				Services: map[types.NamespacedName]providerir.ServiceContext{
 					{Namespace: testNamespace, Name: testServiceName}: {
-						Gce: &gce.ServiceIR{
-							SessionAffinity: &gce.SessionAffinityConfig{
-								AffinityType: saTypeCookie,
-								CookieTTLSec: common.PtrTo(testCookieTTLSec),
-							},
+						SessionAffinity: &providerir.SessionAffinityConfig{
+							AffinityType: saTypeCookie,
+							CookieTTLSec: common.PtrTo(testCookieTTLSec),
 						},
 					},
 				},
@@ -713,11 +709,13 @@ func Test_convertToIR(t *testing.T) {
 						},
 					},
 				},
-				Services: map[types.NamespacedName]providerir.ProviderSpecificServiceIR{
+				Services: map[types.NamespacedName]providerir.ServiceContext{
 					{Namespace: testNamespace, Name: testServiceName}: {
-						Gce: &gce.ServiceIR{
-							SecurityPolicy: &gce.SecurityPolicyConfig{
-								Name: testSecurityPolicy,
+						ProviderSpecificIR: providerir.ProviderSpecificServiceIR{
+							Gce: &gce.ServiceIR{
+								SecurityPolicy: &gce.SecurityPolicyConfig{
+									Name: testSecurityPolicy,
+								},
 							},
 						},
 					},
@@ -804,17 +802,19 @@ func Test_convertToIR(t *testing.T) {
 						},
 					},
 				},
-				Services: map[types.NamespacedName]providerir.ProviderSpecificServiceIR{
+				Services: map[types.NamespacedName]providerir.ServiceContext{
 					{Namespace: testNamespace, Name: testServiceName}: {
-						Gce: &gce.ServiceIR{
-							HealthCheck: &gce.HealthCheckConfig{
-								CheckIntervalSec:   common.PtrTo(testCheckIntervalSec),
-								TimeoutSec:         common.PtrTo(testTimeoutSec),
-								HealthyThreshold:   common.PtrTo(testHealthyThreshold),
-								UnhealthyThreshold: common.PtrTo(testUnhealthyThreshold),
-								Type:               common.PtrTo(protocolHTTP),
-								Port:               common.PtrTo(testPort),
-								RequestPath:        common.PtrTo(testRequestPath),
+						ProviderSpecificIR: providerir.ProviderSpecificServiceIR{
+							Gce: &gce.ServiceIR{
+								HealthCheck: &gce.HealthCheckConfig{
+									CheckIntervalSec:   common.PtrTo(testCheckIntervalSec),
+									TimeoutSec:         common.PtrTo(testTimeoutSec),
+									HealthyThreshold:   common.PtrTo(testHealthyThreshold),
+									UnhealthyThreshold: common.PtrTo(testUnhealthyThreshold),
+									Type:               common.PtrTo(protocolHTTP),
+									Port:               common.PtrTo(testPort),
+									RequestPath:        common.PtrTo(testRequestPath),
+								},
 							},
 						},
 					},

--- a/pkg/i2gw/providers/ingressnginx/affinity.go
+++ b/pkg/i2gw/providers/ingressnginx/affinity.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ingressnginx
+
+import (
+	"strconv"
+
+	"github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw/emitter_intermediate/gce"
+	providerir "github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw/provider_intermediate"
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+// affinityFeature parses the ingress-nginx affinity annotations and populates
+// the ProviderSpecificServiceIR.Gce.SessionAffinity.
+func affinityFeature(_ []networkingv1.Ingress, _ map[types.NamespacedName]map[string]int32, ir *providerir.ProviderIR) field.ErrorList {
+	var errs field.ErrorList
+
+	for _, httpRouteCtx := range ir.HTTPRoutes {
+		for ruleIdx, rule := range httpRouteCtx.Spec.Rules {
+			if ruleIdx >= len(httpRouteCtx.RuleBackendSources) {
+				continue
+			}
+			sources := httpRouteCtx.RuleBackendSources[ruleIdx]
+			if len(sources) == 0 {
+				continue
+			}
+
+			// Check if the source ingress has the affinity annotation.
+			ingress := getNonCanaryIngress(sources)
+			if ingress == nil {
+				continue
+			}
+
+			affinityVal, ok := ingress.Annotations[AffinityAnnotation]
+			if !ok || affinityVal != "cookie" {
+				// Only "cookie" affinity is supported for GCE.
+				continue
+			}
+
+			var cookieTTLSecPtr *int64
+			maxAgeVal, ok := ingress.Annotations[SessionCookieMaxAgeAnnotation]
+			if ok && maxAgeVal != "" {
+				parsedTTL, err := strconv.ParseInt(maxAgeVal, 10, 64)
+				if err != nil {
+					errs = append(errs, field.Invalid(
+						field.NewPath("metadata", "annotations", SessionCookieMaxAgeAnnotation),
+						maxAgeVal,
+						"must be an integer",
+					))
+				} else if parsedTTL < 0 || parsedTTL > 1209600 {
+					errs = append(errs, field.Invalid(
+						field.NewPath("metadata", "annotations", SessionCookieMaxAgeAnnotation),
+						maxAgeVal,
+						"must be between 0 and 1209600 seconds",
+					))
+				} else {
+					cookieTTLSecPtr = &parsedTTL
+				}
+			}
+
+			for _, backendRef := range rule.BackendRefs {
+				if backendRef.Kind != nil && *backendRef.Kind != "Service" {
+					continue
+				}
+
+				svcName := string(backendRef.Name)
+				svcNamespace := ingress.Namespace
+				if backendRef.Namespace != nil {
+					svcNamespace = string(*backendRef.Namespace)
+				}
+
+				svcKey := types.NamespacedName{Namespace: svcNamespace, Name: svcName}
+
+				svcCtx := ir.Services[svcKey]
+				if svcCtx.Gce == nil {
+					svcCtx.Gce = &gce.ServiceIR{}
+				}
+
+				svcCtx.Gce.SessionAffinity = &gce.SessionAffinityConfig{
+					AffinityType: "GENERATED_COOKIE",
+					CookieTTLSec: cookieTTLSecPtr,
+				}
+				ir.Services[svcKey] = svcCtx
+			}
+		}
+	}
+	return errs
+}

--- a/pkg/i2gw/providers/ingressnginx/affinity.go
+++ b/pkg/i2gw/providers/ingressnginx/affinity.go
@@ -19,7 +19,6 @@ package ingressnginx
 import (
 	"strconv"
 
-	"github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw/emitter_intermediate/gce"
 	providerir "github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw/provider_intermediate"
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -88,11 +87,7 @@ func affinityFeature(_ []networkingv1.Ingress, _ map[types.NamespacedName]map[st
 				svcKey := types.NamespacedName{Namespace: svcNamespace, Name: svcName}
 
 				svcCtx := ir.Services[svcKey]
-				if svcCtx.Gce == nil {
-					svcCtx.Gce = &gce.ServiceIR{}
-				}
-
-				svcCtx.Gce.SessionAffinity = &gce.SessionAffinityConfig{
+				svcCtx.SessionAffinity = &providerir.SessionAffinityConfig{
 					AffinityType: "GENERATED_COOKIE",
 					CookieTTLSec: cookieTTLSecPtr,
 				}

--- a/pkg/i2gw/providers/ingressnginx/affinity_test.go
+++ b/pkg/i2gw/providers/ingressnginx/affinity_test.go
@@ -1,0 +1,156 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ingressnginx
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw/emitter_intermediate/gce"
+	providerir "github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw/provider_intermediate"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func TestAffinityFeature(t *testing.T) {
+	testCases := []struct {
+		name      string
+		ingresses []networkingv1.Ingress
+		pIR       *providerir.ProviderIR
+		expected  *providerir.ProviderIR
+	}{
+		{
+			name: "valid affinity with max-age",
+			ingresses: []networkingv1.Ingress{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-ing",
+						Namespace: "default",
+						Annotations: map[string]string{
+							AffinityAnnotation:            "cookie",
+							SessionCookieMaxAgeAnnotation: "172800",
+						},
+					},
+				},
+			},
+			pIR: &providerir.ProviderIR{
+				HTTPRoutes: map[types.NamespacedName]providerir.HTTPRouteContext{
+					{Namespace: "default", Name: "test-route"}: {
+						HTTPRoute: gatewayv1.HTTPRoute{
+							Spec: gatewayv1.HTTPRouteSpec{
+								Rules: []gatewayv1.HTTPRouteRule{
+									{
+										BackendRefs: []gatewayv1.HTTPBackendRef{
+											{
+												BackendRef: gatewayv1.BackendRef{
+													BackendObjectReference: gatewayv1.BackendObjectReference{
+														Name: "test-svc",
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						RuleBackendSources: [][]providerir.BackendSource{
+							{
+								{
+									Ingress: &networkingv1.Ingress{
+										ObjectMeta: metav1.ObjectMeta{
+											Name:      "test-ing",
+											Namespace: "default",
+											Annotations: map[string]string{
+												AffinityAnnotation:            "cookie",
+												SessionCookieMaxAgeAnnotation: "172800",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Services: map[types.NamespacedName]providerir.ProviderSpecificServiceIR{},
+			},
+			expected: &providerir.ProviderIR{
+				HTTPRoutes: map[types.NamespacedName]providerir.HTTPRouteContext{
+					{Namespace: "default", Name: "test-route"}: {
+						HTTPRoute: gatewayv1.HTTPRoute{
+							Spec: gatewayv1.HTTPRouteSpec{
+								Rules: []gatewayv1.HTTPRouteRule{
+									{
+										BackendRefs: []gatewayv1.HTTPBackendRef{
+											{
+												BackendRef: gatewayv1.BackendRef{
+													BackendObjectReference: gatewayv1.BackendObjectReference{
+														Name: "test-svc",
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						RuleBackendSources: [][]providerir.BackendSource{
+							{
+								{
+									Ingress: &networkingv1.Ingress{
+										ObjectMeta: metav1.ObjectMeta{
+											Name:      "test-ing",
+											Namespace: "default",
+											Annotations: map[string]string{
+												AffinityAnnotation:            "cookie",
+												SessionCookieMaxAgeAnnotation: "172800",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Services: map[types.NamespacedName]providerir.ProviderSpecificServiceIR{
+					{Namespace: "default", Name: "test-svc"}: {
+						Gce: &gce.ServiceIR{
+							SessionAffinity: &gce.SessionAffinityConfig{
+								AffinityType: "GENERATED_COOKIE",
+								CookieTTLSec: ptr.To[int64](172800),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			errs := affinityFeature(tc.ingresses, nil, tc.pIR)
+			if len(errs) > 0 {
+				t.Fatalf("unexpected errors: %v", errs)
+			}
+			if diff := cmp.Diff(tc.expected, tc.pIR); diff != "" {
+				t.Errorf("affinityFeature() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/i2gw/providers/ingressnginx/affinity_test.go
+++ b/pkg/i2gw/providers/ingressnginx/affinity_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw/emitter_intermediate/gce"
 	providerir "github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw/provider_intermediate"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -88,7 +87,7 @@ func TestAffinityFeature(t *testing.T) {
 						},
 					},
 				},
-				Services: map[types.NamespacedName]providerir.ProviderSpecificServiceIR{},
+				Services: map[types.NamespacedName]providerir.ServiceContext{},
 			},
 			expected: &providerir.ProviderIR{
 				HTTPRoutes: map[types.NamespacedName]providerir.HTTPRouteContext{
@@ -128,13 +127,11 @@ func TestAffinityFeature(t *testing.T) {
 						},
 					},
 				},
-				Services: map[types.NamespacedName]providerir.ProviderSpecificServiceIR{
+				Services: map[types.NamespacedName]providerir.ServiceContext{
 					{Namespace: "default", Name: "test-svc"}: {
-						Gce: &gce.ServiceIR{
-							SessionAffinity: &gce.SessionAffinityConfig{
-								AffinityType: "GENERATED_COOKIE",
-								CookieTTLSec: ptr.To[int64](172800),
-							},
+						SessionAffinity: &providerir.SessionAffinityConfig{
+							AffinityType: "GENERATED_COOKIE",
+							CookieTTLSec: ptr.To[int64](172800),
 						},
 					},
 				},

--- a/pkg/i2gw/providers/ingressnginx/annotations.go
+++ b/pkg/i2gw/providers/ingressnginx/annotations.go
@@ -63,4 +63,9 @@ const (
 	// IP Range Control annotations
 	WhiteListSourceRangeAnnotation = "nginx.ingress.kubernetes.io/whitelist-source-range"
 	DenyListSourceRangeAnnotation  = "nginx.ingress.kubernetes.io/denylist-source-range"
+
+	// Affinity annotations
+	AffinityAnnotation            = "nginx.ingress.kubernetes.io/affinity"
+	AffinityModeAnnotation        = "nginx.ingress.kubernetes.io/affinity-mode"
+	SessionCookieMaxAgeAnnotation = "nginx.ingress.kubernetes.io/session-cookie-max-age"
 )

--- a/pkg/i2gw/providers/ingressnginx/converter.go
+++ b/pkg/i2gw/providers/ingressnginx/converter.go
@@ -33,6 +33,7 @@ type resourcesToIRConverter struct {
 func newResourcesToIRConverter() *resourcesToIRConverter {
 	return &resourcesToIRConverter{
 		featureParsers: []i2gw.FeatureParser{
+			affinityFeature,
 			canaryFeature,
 			headerModifierFeature,
 			regexFeature,

--- a/pkg/i2gw/providers/nginx/annotations/grpc_services.go
+++ b/pkg/i2gw/providers/nginx/annotations/grpc_services.go
@@ -64,7 +64,7 @@ func processGRPCServicesAnnotation(ingress networkingv1.Ingress, grpcServices st
 
 	// Mark services as gRPC in provider-specific IR
 	if ir.Services == nil {
-		ir.Services = make(map[types.NamespacedName]providerir.ProviderSpecificServiceIR)
+		ir.Services = make(map[types.NamespacedName]providerir.ServiceContext)
 	}
 
 	// Process each ingress rule that uses gRPC services


### PR DESCRIPTION
**What type of PR is this?**
/kind feature


**What this PR does / why we need it**:

This PR introduces support for parsing Nginx Ingress session affinity annotations and translating them to GKE Gateway API resources. 
Specifically, this PR:
* Adds parsing for `nginx.ingress.kubernetes.io/affinity` and `nginx.ingress.kubernetes.io/session-cookie-max-age` in the `ingress-nginx` provider.
* Automatically generates a `GCPBackendPolicy` with `SessionAffinityConfig` set to `GENERATED_COOKIE` when `affinity: "cookie"` is detected and the tool is run with `--emitters=gce`.
* Maps `session-cookie-max-age` to `CookieTTLSec` with strict bound-checking `[0, 1209600]` (14 days) to align with GCP's API constraints, surfacing validation errors early for invalid configurations.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Added support for translating Nginx Ingress annotations `affinity: "cookie"` and `session-cookie-max-age` into `GCPBackendPolicy` SessionAffinityConfigs when using the `gce` emitter.
```
