### PR TITLE
Bump Kong chart to v3.0.2

### DIFF
--- a/e2e/gwapi_kong.go
+++ b/e2e/gwapi_kong.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	kongChartVersion   = "2.42.0"
+	kongChartVersion   = "3.0.2"
 	kongChartRepo      = "https://charts.konghq.com"
 	kongGatewayClass   = "kong"
 	kongControllerName = "konghq.com/kic-gateway-controller"


### PR DESCRIPTION
This PR bumps the Kong chart to v3.0.2.

We need this change because the current Kong version uses GWAPI `v1.1.0` which is incompatible with some of the other implementations. Specifically, the `SupportedFeature` type in `GatewayClassStatus.supportedFeatures` changed from a string to a struct in GWAPI `v1.2.0`.

https://github.com/kubernetes-sigs/gateway-api/releases/tag/v1.2.0