### PR TITLE
remove copyright years after 2025

### DIFF
--- a/e2e/gwapi_kgateway.go
+++ b/e2e/gwapi_kgateway.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/e2e/ingress_nginx_canary_test.go
+++ b/e2e/ingress_nginx_canary_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/e2e/ingress_nginx_cors_test.go
+++ b/e2e/ingress_nginx_cors_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/e2e/ingress_nginx_path_rewrite_test.go
+++ b/e2e/ingress_nginx_path_rewrite_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/e2e/ingress_nginx_tls_test.go
+++ b/e2e/ingress_nginx_tls_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/e2e/secrets.go
+++ b/e2e/secrets.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/hack/boilerplate/boilerplate.go.txt
+++ b/hack/boilerplate/boilerplate.go.txt
@@ -1,5 +1,5 @@
 /*
-Copyright YEAR The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/hack/boilerplate/boilerplate.py
+++ b/hack/boilerplate/boilerplate.py
@@ -14,10 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This file is copied from https://github.com/kubernetes/kubernetes/blob/04c2b1fbdc1289c9a72eda87cf7072346e60d241/hack/boilerplate/boilerplate.py
-
-from __future__ import print_function
-
 import argparse
 import datetime
 import difflib
@@ -28,23 +24,22 @@ import sys
 
 parser = argparse.ArgumentParser()
 parser.add_argument(
-    "filenames",
-    help="list of files to check, all files if unspecified",
-    nargs='*')
+    "filenames", help="list of files to check, all files if unspecified", nargs="*"
+)
 
 rootdir = os.path.dirname(__file__) + "/../../"
 rootdir = os.path.abspath(rootdir)
-parser.add_argument(
-    "--rootdir", default=rootdir, help="root directory to examine")
+parser.add_argument("--rootdir", default=rootdir, help="root directory to examine")
 
 default_boilerplate_dir = os.path.join(rootdir, "hack/boilerplate")
-parser.add_argument(
-    "--boilerplate-dir", default=default_boilerplate_dir)
+parser.add_argument("--boilerplate-dir", default=default_boilerplate_dir)
 
 parser.add_argument(
-    "-v", "--verbose",
+    "-v",
+    "--verbose",
     help="give verbose output regarding why a file does not pass",
-    action="store_true")
+    action="store_true",
+)
 
 args = parser.parse_args()
 
@@ -57,43 +52,32 @@ def get_refs():
     for path in glob.glob(os.path.join(args.boilerplate_dir, "boilerplate.*.txt")):
         extension = os.path.basename(path).split(".")[1]
 
-        ref_file = open(path, 'r')
-        ref = ref_file.read().splitlines()
-        ref_file.close()
-        refs[extension] = ref
+        with open(path, "r") as ref_file:
+            refs[extension] = ref_file.read().splitlines()
 
     return refs
 
 
-def is_generated_file(filename, data, regexs):
-    for d in skipped_ungenerated_files:
-        if d in filename:
-            return False
-
-    p = regexs["generated"]
-    return p.search(data)
+def is_generated_file(data, regexs):
+    return regexs["generated"].search(data)
 
 
 def file_passes(filename, refs, regexs):
     try:
-        f = open(filename, 'r')
-    except Exception as exc:
-        print("Unable to open %s: %s" % (filename, exc), file=verbose_out)
+        with open(filename) as stream:
+            data = stream.read()
+    except OSError as exc:
+        print(f"Unable to open {filename}: {exc}", file=verbose_out)
         return False
 
-    data = f.read()
-    f.close()
-
     # determine if the file is automatically generated
-    generated = is_generated_file(filename, data, regexs)
+    generated = is_generated_file(data, regexs)
 
     basename = os.path.basename(filename)
     extension = file_extension(filename)
     if generated:
         if extension == "go":
             extension = "generatego"
-        elif extension == "bzl":
-            extension = "generatebzl"
 
     if extension != "":
         ref = refs[extension]
@@ -101,51 +85,40 @@ def file_passes(filename, refs, regexs):
         ref = refs[basename]
 
     # remove extra content from the top of files
-    if extension == "go" or extension == "generatego":
-        p = regexs["go_build_constraints"]
-        (data, found) = p.subn("", data, 1)
+    if extension in ("go", "generatego"):
+        data, found = regexs["go_build_constraints"].subn("", data, 1)
     elif extension in ["sh", "py"]:
-        p = regexs["shebang"]
-        (data, found) = p.subn("", data, 1)
+        data, found = regexs["shebang"].subn("", data, 1)
 
     data = data.splitlines()
 
     # if our test file is smaller than the reference it surely fails!
     if len(ref) > len(data):
-        print('File %s smaller than reference (%d < %d)' %
-              (filename, len(data), len(ref)),
-              file=verbose_out)
+        print(
+            f"File {filename} smaller than reference ({len(data)} < {len(ref)})",
+            file=verbose_out,
+        )
         return False
 
     # trim our file to the same number of lines as the reference file
-    data = data[:len(ref)]
-
-    p = regexs["year"]
-    for d in data:
-        if p.search(d):
-            if generated:
-                print('File %s has the YEAR field, but it should not be in generated file' %
-                      filename, file=verbose_out)
-            else:
-                print('File %s has the YEAR field, but missing the year of date' %
-                      filename, file=verbose_out)
-            return False
+    data = data[: len(ref)]
 
     if not generated:
-        # Replace all occurrences of the regex "2014|2015|2016|2017|2018" with "YEAR"
-        p = regexs["date"]
-        for i, d in enumerate(data):
-            (data[i], found) = p.subn('YEAR', d)
+        # Remove all occurrences of the year (regex "Copyright (2014|2015|2016|2017|2018) ")
+        pattern = regexs["date"]
+        for i, line in enumerate(data):
+            data[i], found = pattern.subn("Copyright ", line)
             if found != 0:
                 break
 
     # if we don't match the reference at this point, fail
     if ref != data:
-        print("Header in %s does not match reference, diff:" %
-              filename, file=verbose_out)
+        print(f"Header in {filename} does not match reference, diff:", file=verbose_out)
         if args.verbose:
             print(file=verbose_out)
-            for line in difflib.unified_diff(ref, data, 'reference', filename, lineterm=''):
+            for line in difflib.unified_diff(
+                ref, data, "reference", filename, lineterm=""
+            ):
                 print(line, file=verbose_out)
             print(file=verbose_out)
         return False
@@ -157,28 +130,23 @@ def file_extension(filename):
     return os.path.splitext(filename)[1].split(".")[-1].lower()
 
 
-skipped_dirs = [
-    'cluster/env.sh',
-    '.git',
-    '_gopath',
-    'hack/boilerplate/test',
-    '_output',
-    'staging/src/k8s.io/kubectl/pkg/generated/bindata.go',
-    'test/e2e/generated/bindata.go',
-    'third_party',
-    'vendor',
-    '.venv',
+skipped_names = [
+    "third_party",
+    "_output",
+    ".git",
+    "cluster/env.sh",
+    "vendor",
+    "testdata",
+    "test/e2e/generated/bindata.go",
+    "hack/boilerplate/test",
+    "staging/src/k8s.io/kubectl/pkg/generated/bindata.go",
 ]
-
-# list all the files contain 'DO NOT EDIT', but are not generated
-skipped_ungenerated_files = [
-    'hack/lib/swagger.sh', 'hack/boilerplate/boilerplate.py']
 
 
 def normalize_files(files):
     newfiles = []
     for pathname in files:
-        if any(x in pathname for x in skipped_dirs):
+        if any(x in pathname for x in skipped_names):
             continue
         newfiles.append(pathname)
     for i, pathname in enumerate(newfiles):
@@ -197,9 +165,13 @@ def get_files(extensions):
             # as we would prune these later in normalize_files(). But doing it
             # cuts down the amount of filesystem walking we do and cuts down
             # the size of the file list
-            for d in skipped_dirs:
-                if d in dirs:
-                    dirs.remove(d)
+            for dname in skipped_names:
+                if dname in dirs:
+                    dirs.remove(dname)
+            for dname in dirs:
+                # dirs that start with __ are ignored
+                if dname.startswith("__"):
+                    dirs.remove(dname)
 
             for name in walkfiles:
                 pathname = os.path.join(root, name)
@@ -216,39 +188,39 @@ def get_files(extensions):
 
 
 def get_dates():
-    years = datetime.datetime.now().year
-    return '(%s)' % '|'.join((str(year) for year in range(2014, years+1)))
+    # After 2025, we no longer allow new files to include the year in the copyright header.
+    final_year = 2025
+    return " (%s) " % "|".join(str(year) for year in range(2014, final_year + 1))
 
 
 def get_regexs():
     regexs = {}
     # Search for "YEAR" which exists in the boilerplate, but shouldn't in the real thing
-    regexs["year"] = re.compile('YEAR')
-    # get_dates return 2014, 2015, 2016, 2017, or 2018 until the current year as a regex like: "(2014|2015|2016|2017|2018)";
-    # company holder names can be anything
-    regexs["date"] = re.compile(get_dates())
+    regexs["year"] = re.compile("YEAR")
+    # get_dates return 2014, 2015, 2016, 2017, ..., 2025
+    # as a regex like: "(2014|2015|2016|2017|2018|...|2025)";
+    regexs["date"] = re.compile("Copyright" + get_dates())
     # strip the following build constraints/tags:
     # //go:build
     # // +build \n\n
     regexs["go_build_constraints"] = re.compile(
-        r"^(//(go:build| \+build).*\n)+\n", re.MULTILINE)
+        r"^(//(go:build| \+build).*\n)+\n", re.MULTILINE
+    )
     # strip #!.* from scripts
     regexs["shebang"] = re.compile(r"^(#!.*\n)\n*", re.MULTILINE)
     # Search for generated files
-    regexs["generated"] = re.compile('DO NOT EDIT')
+    regexs["generated"] = re.compile(r"^[/*#]+ +.* DO NOT EDIT\.$", re.MULTILINE)
     return regexs
 
 
 def main():
     regexs = get_regexs()
     refs = get_refs()
-    filenames = get_files(refs.keys())
+    filenames = get_files(refs)
 
     for filename in filenames:
         if not file_passes(filename, refs, regexs):
-            print(filename, file=sys.stdout)
-
-    print("Verified %d file headers match boilerplate" % (len(filenames),), file=sys.stderr)
+            print(filename)
 
     return 0
 

--- a/hack/boilerplate/boilerplate.py.txt
+++ b/hack/boilerplate/boilerplate.py.txt
@@ -1,4 +1,4 @@
-# Copyright YEAR The Kubernetes Authors.
+# Copyright The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/boilerplate/boilerplate.sh.txt
+++ b/hack/boilerplate/boilerplate.sh.txt
@@ -1,4 +1,4 @@
-# Copyright YEAR The Kubernetes Authors.
+# Copyright The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pkg/i2gw/emitters/common_emitter/emitter_test.go
+++ b/pkg/i2gw/emitters/common_emitter/emitter_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/i2gw/emitters/envoygateway/buffer.go
+++ b/pkg/i2gw/emitters/envoygateway/buffer.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/i2gw/emitters/envoygateway/builder.go
+++ b/pkg/i2gw/emitters/envoygateway/builder.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/i2gw/emitters/envoygateway/consts.go
+++ b/pkg/i2gw/emitters/envoygateway/consts.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/i2gw/emitters/envoygateway/emitter.go
+++ b/pkg/i2gw/emitters/envoygateway/emitter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/i2gw/emitters/envoygateway/iprange.go
+++ b/pkg/i2gw/emitters/envoygateway/iprange.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/i2gw/emitters/envoygateway/notification.go
+++ b/pkg/i2gw/emitters/envoygateway/notification.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/i2gw/emitters/envoygateway/utils.go
+++ b/pkg/i2gw/emitters/envoygateway/utils.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/i2gw/emitters/envoygateway/utils_test.go
+++ b/pkg/i2gw/emitters/envoygateway/utils_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/i2gw/emitters/kgateway/buffer.go
+++ b/pkg/i2gw/emitters/kgateway/buffer.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/i2gw/emitters/kgateway/builder.go
+++ b/pkg/i2gw/emitters/kgateway/builder.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/i2gw/emitters/kgateway/emitter.go
+++ b/pkg/i2gw/emitters/kgateway/emitter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/i2gw/emitters/kgateway/notification.go
+++ b/pkg/i2gw/emitters/kgateway/notification.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/i2gw/emitters/kgateway/types.go
+++ b/pkg/i2gw/emitters/kgateway/types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/i2gw/providers/ingressnginx/annotations.go
+++ b/pkg/i2gw/providers/ingressnginx/annotations.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/i2gw/providers/ingressnginx/bodysize.go
+++ b/pkg/i2gw/providers/ingressnginx/bodysize.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/i2gw/providers/ingressnginx/bodysize_test.go
+++ b/pkg/i2gw/providers/ingressnginx/bodysize_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/i2gw/providers/ingressnginx/cors.go
+++ b/pkg/i2gw/providers/ingressnginx/cors.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/i2gw/providers/ingressnginx/cors_test.go
+++ b/pkg/i2gw/providers/ingressnginx/cors_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/i2gw/providers/ingressnginx/headers.go
+++ b/pkg/i2gw/providers/ingressnginx/headers.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/i2gw/providers/ingressnginx/headers_test.go
+++ b/pkg/i2gw/providers/ingressnginx/headers_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/i2gw/providers/ingressnginx/iprange.go
+++ b/pkg/i2gw/providers/ingressnginx/iprange.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/i2gw/providers/ingressnginx/iprange_test.go
+++ b/pkg/i2gw/providers/ingressnginx/iprange_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/i2gw/providers/ingressnginx/redirect.go
+++ b/pkg/i2gw/providers/ingressnginx/redirect.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/i2gw/providers/ingressnginx/redirect_test.go
+++ b/pkg/i2gw/providers/ingressnginx/redirect_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/i2gw/providers/ingressnginx/regex.go
+++ b/pkg/i2gw/providers/ingressnginx/regex.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/i2gw/providers/ingressnginx/regex_test.go
+++ b/pkg/i2gw/providers/ingressnginx/regex_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/i2gw/providers/ingressnginx/rewrite_test.go
+++ b/pkg/i2gw/providers/ingressnginx/rewrite_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/i2gw/providers/ingressnginx/timeouts.go
+++ b/pkg/i2gw/providers/ingressnginx/timeouts.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/i2gw/providers/ingressnginx/timeouts_test.go
+++ b/pkg/i2gw/providers/ingressnginx/timeouts_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/i2gw/providers/ingressnginx/utils.go
+++ b/pkg/i2gw/providers/ingressnginx/utils.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
This commit copies over a similar commit from kubernetes/kubernetes: https://github.com/kubernetes/kubernetes/pull/134835

Per https://github.com/kubernetes/steering/issues/299, we no longer require copyright years in the file boilerplate for Kubernetes projects.

/kind cleanup
