### PR TITLE
support cors output without experimental flag

### DIFF
--- a/cmd/print.go
+++ b/cmd/print.go
@@ -85,7 +85,7 @@ type PrintRunner struct {
 	// Defaults to "standard".
 	emitter string
 
-	// allowExperimentalGatewayAPI indicates whether Experimental Gateway API features (like CORS, URLRewrite) should be included in the output.
+	// allowExperimentalGatewayAPI indicates whether Experimental Gateway API features (like URLRewrite) should be included in the output.
 	allowExperimentalGatewayAPI bool
 }
 
@@ -421,7 +421,7 @@ if specified with --namespace.`)
 	cmd.Flags().StringSliceVar(&pr.providers, "providers", []string{},
 		fmt.Sprintf("If present, the tool will try to convert only resources related to the specified providers, supported values are %v.", i2gw.GetSupportedProviders()))
 
-	cmd.Flags().BoolVar(&pr.allowExperimentalGatewayAPI, "allow-experimental-gw-api", false, "If present, the tool will include Experimental Gateway API fields (e.g. CORS, URLRewrite) in the output. Default is false.")
+	cmd.Flags().BoolVar(&pr.allowExperimentalGatewayAPI, "allow-experimental-gw-api", false, "If present, the tool will include Experimental Gateway API fields (e.g. URLRewrite) in the output. Default is false.")
 
 	pr.providerSpecificFlags = make(map[string]*string)
 	for provider, flags := range i2gw.GetProviderSpecificFlagDefinitions() {

--- a/pkg/i2gw/emitter.go
+++ b/pkg/i2gw/emitter.go
@@ -60,6 +60,6 @@ type EmitterName string
 type EmitterConstructor func(conf *EmitterConf) Emitter
 
 type EmitterConf struct {
-	// AllowExperimentalGatewayAPI indicates whether Experimental Gateway API features (like CORS, URLRewrite) should be included in the output.
+	// AllowExperimentalGatewayAPI indicates whether Experimental Gateway API features (like URLRewrite) should be included in the output.
 	AllowExperimentalGatewayAPI bool
 }

--- a/pkg/i2gw/emitters/common_emitter/emitter.go
+++ b/pkg/i2gw/emitters/common_emitter/emitter.go
@@ -72,9 +72,6 @@ func applyPathRewrites(ir *emitterir.EmitterIR) {
 }
 
 func (e *Emitter) applyCorsPolicies(ir *emitterir.EmitterIR) {
-	if e.conf != nil && !e.conf.AllowExperimentalGatewayAPI {
-		return
-	}
 	for key, routeCtx := range ir.HTTPRoutes {
 		for ruleIdx, policy := range routeCtx.CorsPolicyByRuleIdx {
 			if policy == nil {

--- a/pkg/i2gw/emitters/common_emitter/emitter_test.go
+++ b/pkg/i2gw/emitters/common_emitter/emitter_test.go
@@ -164,7 +164,7 @@ func TestEmitCORSFiltering(t *testing.T) {
 			name:                 "experimental denied + cors in sidecar -> cors NOT added",
 			allowExperimental:    false,
 			corsInSidecar:        &gatewayv1.HTTPCORSFilter{},
-			expectedFiltersCount: 0,
+			expectedFiltersCount: 1,
 		},
 		{
 			name:              "other filters preserved regardless of flag",
@@ -173,7 +173,7 @@ func TestEmitCORSFiltering(t *testing.T) {
 				{Type: gatewayv1.HTTPRouteFilterRequestHeaderModifier},
 			},
 			corsInSidecar:        &gatewayv1.HTTPCORSFilter{},
-			expectedFiltersCount: 1, // only header modifier
+			expectedFiltersCount: 2,
 		},
 	}
 


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/ingress2gateway/blob/main/CONTRIBUTING.md). -->

<!-- The release notes and the kind will be used to generate the Changelog for the release. To make sure your contribution is recognized, please label this pull request according to what type of issue you are addressing and add the release notes when necessary (see ../CONTRIBUTING.md) -->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

**What this PR does / why we need it**:
Support CORS Filter output without experimental flag.
Currently we've released GWAPI v1.5.0 and this repo imports v1.5.0.
CORS Filter becomes GA in v1.5.0.
https://github.com/kubernetes-sigs/gateway-api/releases/tag/v1.5.0

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
