### PR TITLE
fix: use binary suffixes (Ki/Mi/Gi) for body size conversion

### DIFF
--- a/pkg/i2gw/providers/ingressnginx/bodysize.go
+++ b/pkg/i2gw/providers/ingressnginx/bodysize.go
@@ -33,24 +33,7 @@ var nginxSizeRegex = regexp.MustCompile(`^(?i)(\d+)([bkmg]?)$`)
 
 // convertNginxSizeToK8sQuantity converts nginx size format to Kubernetes resource.Quantity format.
 //
-// nginx uses suffixes for byte sizes:
-//   - b = bytes
-//   - k = kilobytes (10^3)
-//   - m = megabytes (10^6)
-//   - g = gigabytes (10^9)
-//
-// Kubernetes resource.Quantity uses different suffixes:
-//   - B = byte (10^3)
-//   - Ki = kilo (10^3)
-//   - Mi = mega (10^6)
-//   - Gi = giga (10^9)
-//
-// This function converts nginx format to K8s format:
-//   - "10b" -> "10" (10 bytes)
-//   - "10k" -> "10Ki" (10 kilobytes, same)
-//   - "10m" -> "10Mi" (10 megabytes)
-//   - "10g" -> "10Gi" (10 gigabytes)
-//   - "100" -> "100" (no unit, same)
+// NGINX uses binary units (e.g. k = 2^10) while in Kubernetes, k = 1000 and Ki = 2^10.
 func convertNginxSizeToK8sQuantity(nginxSize string) (string, error) {
 	nginxSize = strings.TrimSpace(nginxSize)
 

--- a/pkg/i2gw/providers/ingressnginx/bodysize_test.go
+++ b/pkg/i2gw/providers/ingressnginx/bodysize_test.go
@@ -41,21 +41,39 @@ func TestConvertNginxSizeToK8sQuantity(t *testing.T) {
 			wantErr:   false,
 		},
 		{
-			name:      "lowercase k stays as k",
+			name:      "k becomes Ki",
 			nginxSize: "100k",
-			want:      "100k",
+			want:      "100Ki",
 			wantErr:   false,
 		},
 		{
-			name:      "lowercase m to K8s Mega",
+			name:      "K becomes as Ki",
+			nginxSize: "100K",
+			want:      "100Ki",
+			wantErr:   false,
+		},
+		{
+			name:      "m to K8s Mega",
 			nginxSize: "10m",
-			want:      "10M",
+			want:      "10Mi",
 			wantErr:   false,
 		},
 		{
-			name:      "lowercase g to K8s Giga",
+			name:      "M to K8s Mega",
+			nginxSize: "10M",
+			want:      "10Mi",
+			wantErr:   false,
+		},
+		{
+			name:      "g to K8s Giga",
 			nginxSize: "5g",
-			want:      "5G",
+			want:      "5Gi",
+			wantErr:   false,
+		},
+		{
+			name:      "G to K8s Giga",
+			nginxSize: "5G",
+			want:      "5Gi",
 			wantErr:   false,
 		},
 		{
@@ -67,7 +85,7 @@ func TestConvertNginxSizeToK8sQuantity(t *testing.T) {
 		{
 			name:      "whitespace trimmed",
 			nginxSize: "  10m  ",
-			want:      "10M",
+			want:      "10Mi",
 			wantErr:   false,
 		},
 		{
@@ -113,8 +131,8 @@ func TestApplyBodySizeToEmitterIR_SetMaxSize(t *testing.T) {
 	if bodySizeIR == nil {
 		t.Fatalf("expected body size IR to be set for rule index 0")
 	}
-	if bodySizeIR.MaxSize.String() != "10M" {
-		t.Fatalf("expected max size 10M, got %s", bodySizeIR.MaxSize.String())
+	if bodySizeIR.MaxSize.String() != "10Mi" {
+		t.Fatalf("expected max size 10Mi, got %s", bodySizeIR.MaxSize.String())
 	}
 }
 
@@ -133,8 +151,8 @@ func TestApplyBodySizeToEmitterIR_SetBufferSize(t *testing.T) {
 	if bodySizeIR == nil {
 		t.Fatalf("expected body size IR to be set for rule index 0")
 	}
-	if bodySizeIR.BufferSize.String() != "10M" {
-		t.Fatalf("expected buffer size 10M, got %s", bodySizeIR.BufferSize.String())
+	if bodySizeIR.BufferSize.String() != "10Mi" {
+		t.Fatalf("expected buffer size 10Mi, got %s", bodySizeIR.BufferSize.String())
 	}
 }
 
@@ -154,11 +172,11 @@ func TestApplyBodySizeToEmitterIR_SetMaxAndBufferSize(t *testing.T) {
 	if bodySizeIR == nil {
 		t.Fatalf("expected body size IR to be set for rule index 0")
 	}
-	if bodySizeIR.MaxSize.String() != "100M" {
-		t.Fatalf("expected max size 100M, got %s", bodySizeIR.MaxSize.String())
+	if bodySizeIR.MaxSize.String() != "100Mi" {
+		t.Fatalf("expected max size 100Mi, got %s", bodySizeIR.MaxSize.String())
 	}
-	if bodySizeIR.BufferSize.String() != "50M" {
-		t.Fatalf("expected buffer size 50M, got %s", bodySizeIR.BufferSize.String())
+	if bodySizeIR.BufferSize.String() != "50Mi" {
+		t.Fatalf("expected buffer size 50Mi, got %s", bodySizeIR.BufferSize.String())
 	}
 }
 


### PR DESCRIPTION
For ingress nginx, `M` is `2^20` bytes while for kubernetes `M` is 10^6 while `Mi` is 2^20`.

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note

```
