### PR TITLE
Move http route rule naming from common provider to emitters

### DIFF
--- a/pkg/i2gw/emitters/agentgateway/agentgateway.go
+++ b/pkg/i2gw/emitters/agentgateway/agentgateway.go
@@ -45,6 +45,7 @@ func NewEmitter(conf *i2gw.EmitterConf) i2gw.Emitter {
 }
 
 func (e *Emitter) Emit(ir emitterir.EmitterIR) (gr i2gw.GatewayResources, errs field.ErrorList) {
+	utils.AddHTTPRouteRuleNames(ir)
 	for ns, gw := range ir.Gateways {
 		gw.Spec.GatewayClassName = emitterName
 		ir.Gateways[ns] = gw

--- a/pkg/i2gw/emitters/envoygateway/emitter.go
+++ b/pkg/i2gw/emitters/envoygateway/emitter.go
@@ -44,6 +44,7 @@ func NewEmitter(conf *i2gw.EmitterConf) i2gw.Emitter {
 }
 
 func (e *Emitter) Emit(ir emitterir.EmitterIR) (i2gw.GatewayResources, field.ErrorList) {
+	utils.AddHTTPRouteRuleNames(ir)
 	gatewayResources, errs := utils.ToGatewayResources(ir)
 	if len(errs) != 0 {
 		return i2gw.GatewayResources{}, errs

--- a/pkg/i2gw/emitters/gce/gce.go
+++ b/pkg/i2gw/emitters/gce/gce.go
@@ -75,20 +75,7 @@ func (c *Emitter) Emit(ir emitterir.EmitterIR) (i2gw.GatewayResources, field.Err
 	buildGceGatewayExtensions(c.notify, ir, &gatewayResources)
 	buildGceServiceExtensions(c.notify, ir, &gatewayResources)
 
-	removeHTTPRouteRuleNames(&gatewayResources)
 	return gatewayResources, nil
-}
-
-func removeHTTPRouteRuleNames(gatewayResources *i2gw.GatewayResources) {
-	for k, route := range gatewayResources.HTTPRoutes {
-		rules := make([]gatewayv1.HTTPRouteRule, len(route.Spec.Rules))
-		copy(rules, route.Spec.Rules)
-		for j := range rules {
-			rules[j].Name = nil
-		}
-		route.Spec.Rules = rules
-		gatewayResources.HTTPRoutes[k] = route
-	}
 }
 
 func buildGceGatewayExtensions(notify notifications.NotifyFunc, ir emitterir.EmitterIR, gatewayResources *i2gw.GatewayResources) {

--- a/pkg/i2gw/emitters/kgateway/emitter.go
+++ b/pkg/i2gw/emitters/kgateway/emitter.go
@@ -48,6 +48,7 @@ func NewEmitter(conf *i2gw.EmitterConf) i2gw.Emitter {
 
 // Emit converts EmitterIR to Gateway API resources plus kgateway-specific extensions
 func (e *Emitter) Emit(ir emitterir.EmitterIR) (i2gw.GatewayResources, field.ErrorList) {
+	utils.AddHTTPRouteRuleNames(ir)
 	gatewayResources, errs := utils.ToGatewayResources(ir)
 	if len(errs) != 0 {
 		return i2gw.GatewayResources{}, errs

--- a/pkg/i2gw/emitters/utils/utils.go
+++ b/pkg/i2gw/emitters/utils/utils.go
@@ -25,6 +25,7 @@ import (
 	"github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw/notifications"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/ptr"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -32,6 +33,18 @@ import (
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
+
+// AddHTTPRouteRuleNames assigns sequential names ("rule-0", "rule-1", etc.)
+// to all HTTPRoute rules in the EmitterIR. Emitters that support the extended
+// HTTPRoute rule name field should call this at the start of their Emit method.
+func AddHTTPRouteRuleNames(ir emitterir.EmitterIR) {
+	for key, ctx := range ir.HTTPRoutes {
+		for idx := range ctx.Spec.Rules {
+			ctx.Spec.Rules[idx].Name = ptr.To(gatewayv1.SectionName(fmt.Sprintf("rule-%d", idx)))
+		}
+		ir.HTTPRoutes[key] = ctx
+	}
+}
 
 type uniqueBackendRefsKey struct {
 	Name      gatewayv1.ObjectName

--- a/pkg/i2gw/providers/common/converter.go
+++ b/pkg/i2gw/providers/common/converter.go
@@ -313,9 +313,6 @@ func (a *ingressAggregator) toRoutesAndGateways(options i2gw.ProviderImplementat
 				BackendRefs: []gatewayv1.HTTPBackendRef{{BackendRef: *backendRef}},
 			})
 		}
-		for idx := range httpRoute.Spec.Rules {
-			httpRoute.Spec.Rules[idx].Name = ptr.To(gatewayv1.SectionName(fmt.Sprintf("rule-%d", idx)))
-		}
 		// Set the single source for this default backend.
 		sources := [][]providerir.BackendSource{
 			{
@@ -459,10 +456,6 @@ func (rg *ingressRuleGroup) toHTTPRoute(servicePorts map[types.NamespacedName]ma
 
 		httpRoute.Spec.Rules = append(httpRoute.Spec.Rules, hrRule)
 		allRuleBackendSources = append(allRuleBackendSources, sources)
-	}
-
-	for idx := range httpRoute.Spec.Rules {
-		httpRoute.Spec.Rules[idx].Name = ptr.To(gatewayv1.SectionName(fmt.Sprintf("rule-%d", idx)))
 	}
 
 	return httpRoute, allRuleBackendSources, errors

--- a/pkg/i2gw/providers/common/converter_test.go
+++ b/pkg/i2gw/providers/common/converter_test.go
@@ -111,7 +111,6 @@ func Test_ToIR(t *testing.T) {
 								},
 								Hostnames: []gatewayv1.Hostname{"example.com"},
 								Rules: []gatewayv1.HTTPRouteRule{{
-									Name: ptr.To(gatewayv1.SectionName("rule-0")),
 									Matches: []gatewayv1.HTTPRouteMatch{{
 										Path: &gatewayv1.HTTPPathMatch{
 											Type:  &gPathPrefix,
@@ -207,7 +206,6 @@ func Test_ToIR(t *testing.T) {
 								},
 								Hostnames: []gatewayv1.Hostname{"example.com"},
 								Rules: []gatewayv1.HTTPRouteRule{{
-									Name: ptr.To(gatewayv1.SectionName("rule-0")),
 									Matches: []gatewayv1.HTTPRouteMatch{{
 										Path: &gatewayv1.HTTPPathMatch{
 											Type:  &gPathPrefix,
@@ -309,7 +307,6 @@ func Test_ToIR(t *testing.T) {
 								},
 								Hostnames: []gatewayv1.Hostname{"foo.example.com"},
 								Rules: []gatewayv1.HTTPRouteRule{{
-									Name: ptr.To(gatewayv1.SectionName("rule-0")),
 									Matches: []gatewayv1.HTTPRouteMatch{{
 										Path: &gatewayv1.HTTPPathMatch{
 											Type:  &gPathPrefix,
@@ -396,7 +393,6 @@ func Test_ToIR(t *testing.T) {
 								},
 								Hostnames: []gatewayv1.Hostname{"example.net"},
 								Rules: []gatewayv1.HTTPRouteRule{{
-									Name: ptr.To(gatewayv1.SectionName("rule-0")),
 									Matches: []gatewayv1.HTTPRouteMatch{{
 										Path: &gatewayv1.HTTPPathMatch{
 											Type:  &gExact,
@@ -426,7 +422,6 @@ func Test_ToIR(t *testing.T) {
 									}},
 								},
 								Rules: []gatewayv1.HTTPRouteRule{{
-									Name: ptr.To(gatewayv1.SectionName("rule-0")),
 									BackendRefs: []gatewayv1.HTTPBackendRef{{
 										BackendRef: gatewayv1.BackendRef{
 											BackendObjectReference: gatewayv1.BackendObjectReference{
@@ -503,7 +498,6 @@ func Test_ToIR(t *testing.T) {
 								},
 								Hostnames: []gatewayv1.Hostname{"example.com"},
 								Rules: []gatewayv1.HTTPRouteRule{{
-									Name: ptr.To(gatewayv1.SectionName("rule-0")),
 									Matches: []gatewayv1.HTTPRouteMatch{{
 										Path: &gatewayv1.HTTPPathMatch{
 											Type:  &gPathPrefix,

--- a/pkg/i2gw/providers/gce/ir_converter_test.go
+++ b/pkg/i2gw/providers/gce/ir_converter_test.go
@@ -110,7 +110,6 @@ func Test_convertToIR(t *testing.T) {
 								Hostnames: []gatewayv1.Hostname{gatewayv1.Hostname(testHost)},
 								Rules: []gatewayv1.HTTPRouteRule{
 									{
-										Name: common.PtrTo(gatewayv1.SectionName("rule-0")),
 										Matches: []gatewayv1.HTTPRouteMatch{
 											{
 												Path: &gatewayv1.HTTPPathMatch{
@@ -175,7 +174,6 @@ func Test_convertToIR(t *testing.T) {
 								Hostnames: []gatewayv1.Hostname{gatewayv1.Hostname(testHost)},
 								Rules: []gatewayv1.HTTPRouteRule{
 									{
-										Name: common.PtrTo(gatewayv1.SectionName("rule-0")),
 										Matches: []gatewayv1.HTTPRouteMatch{
 											{
 												Path: &gatewayv1.HTTPPathMatch{
@@ -241,7 +239,6 @@ func Test_convertToIR(t *testing.T) {
 								Hostnames: []gatewayv1.Hostname{gatewayv1.Hostname(testHost)},
 								Rules: []gatewayv1.HTTPRouteRule{
 									{
-										Name: common.PtrTo(gatewayv1.SectionName("rule-0")),
 										Matches: []gatewayv1.HTTPRouteMatch{
 											{
 												Path: &gatewayv1.HTTPPathMatch{
@@ -308,7 +305,6 @@ func Test_convertToIR(t *testing.T) {
 								Hostnames: []gatewayv1.Hostname{gatewayv1.Hostname(testHost)},
 								Rules: []gatewayv1.HTTPRouteRule{
 									{
-										Name: common.PtrTo(gatewayv1.SectionName("rule-0")),
 										Matches: []gatewayv1.HTTPRouteMatch{
 											{
 												Path: &gatewayv1.HTTPPathMatch{
@@ -375,7 +371,6 @@ func Test_convertToIR(t *testing.T) {
 								Hostnames: []gatewayv1.Hostname{gatewayv1.Hostname(testHost)},
 								Rules: []gatewayv1.HTTPRouteRule{
 									{
-										Name: common.PtrTo(gatewayv1.SectionName("rule-0")),
 										Matches: []gatewayv1.HTTPRouteMatch{
 											{
 												Path: &gatewayv1.HTTPPathMatch{
@@ -442,7 +437,6 @@ func Test_convertToIR(t *testing.T) {
 								Hostnames: []gatewayv1.Hostname{gatewayv1.Hostname(testHost)},
 								Rules: []gatewayv1.HTTPRouteRule{
 									{
-										Name: common.PtrTo(gatewayv1.SectionName("rule-0")),
 										Matches: []gatewayv1.HTTPRouteMatch{
 											{
 												Path: &gatewayv1.HTTPPathMatch{
@@ -518,7 +512,6 @@ func Test_convertToIR(t *testing.T) {
 								Hostnames: []gatewayv1.Hostname{gatewayv1.Hostname(testHost)},
 								Rules: []gatewayv1.HTTPRouteRule{
 									{
-										Name: common.PtrTo(gatewayv1.SectionName("rule-0")),
 										Matches: []gatewayv1.HTTPRouteMatch{
 											{
 												Path: &gatewayv1.HTTPPathMatch{
@@ -604,7 +597,6 @@ func Test_convertToIR(t *testing.T) {
 								Hostnames: []gatewayv1.Hostname{gatewayv1.Hostname(testHost)},
 								Rules: []gatewayv1.HTTPRouteRule{
 									{
-										Name: common.PtrTo(gatewayv1.SectionName("rule-0")),
 										Matches: []gatewayv1.HTTPRouteMatch{
 											{
 												Path: &gatewayv1.HTTPPathMatch{
@@ -690,7 +682,6 @@ func Test_convertToIR(t *testing.T) {
 								Hostnames: []gatewayv1.Hostname{gatewayv1.Hostname(testHost)},
 								Rules: []gatewayv1.HTTPRouteRule{
 									{
-										Name: common.PtrTo(gatewayv1.SectionName("rule-0")),
 										Matches: []gatewayv1.HTTPRouteMatch{
 											{
 												Path: &gatewayv1.HTTPPathMatch{
@@ -781,7 +772,6 @@ func Test_convertToIR(t *testing.T) {
 								Hostnames: []gatewayv1.Hostname{gatewayv1.Hostname(testHost)},
 								Rules: []gatewayv1.HTTPRouteRule{
 									{
-										Name: common.PtrTo(gatewayv1.SectionName("rule-0")),
 										Matches: []gatewayv1.HTTPRouteMatch{
 											{
 												Path: &gatewayv1.HTTPPathMatch{
@@ -876,7 +866,6 @@ func Test_convertToIR(t *testing.T) {
 								Hostnames: []gatewayv1.Hostname{gatewayv1.Hostname(testHost)},
 								Rules: []gatewayv1.HTTPRouteRule{
 									{
-										Name: common.PtrTo(gatewayv1.SectionName("rule-0")),
 										Matches: []gatewayv1.HTTPRouteMatch{
 											{
 												Path: &gatewayv1.HTTPPathMatch{
@@ -943,7 +932,6 @@ func Test_convertToIR(t *testing.T) {
 								Hostnames: []gatewayv1.Hostname{gatewayv1.Hostname(testHost)},
 								Rules: []gatewayv1.HTTPRouteRule{
 									{
-										Name: common.PtrTo(gatewayv1.SectionName("rule-0")),
 										Matches: []gatewayv1.HTTPRouteMatch{
 											{
 												Path: &gatewayv1.HTTPPathMatch{

--- a/pkg/i2gw/providers/ingressnginx/converter_test.go
+++ b/pkg/i2gw/providers/ingressnginx/converter_test.go
@@ -140,7 +140,6 @@ func Test_ToIR(t *testing.T) {
 								},
 								Hostnames: []gatewayv1.Hostname{"echo.prod.mydomain.com"},
 								Rules: []gatewayv1.HTTPRouteRule{{
-									Name: ptrTo(gatewayv1.SectionName("rule-0")),
 									Matches: []gatewayv1.HTTPRouteMatch{{
 										Path: &gatewayv1.HTTPPathMatch{
 											Type:  &gPathPrefix,
@@ -269,7 +268,6 @@ func Test_ToIR(t *testing.T) {
 								},
 								Hostnames: []gatewayv1.Hostname{"echo.prod.mydomain.com"},
 								Rules: []gatewayv1.HTTPRouteRule{{
-									Name: ptrTo(gatewayv1.SectionName("rule-0")),
 									Matches: []gatewayv1.HTTPRouteMatch{{
 										Path: &gatewayv1.HTTPPathMatch{
 											Type:  &gPathPrefix,
@@ -370,7 +368,6 @@ func Test_ToIR(t *testing.T) {
 								},
 								Hostnames: []gatewayv1.Hostname{"test.mydomain.com"},
 								Rules: []gatewayv1.HTTPRouteRule{{
-									Name: ptrTo(gatewayv1.SectionName("rule-0")),
 									Matches: []gatewayv1.HTTPRouteMatch{{
 										Path: &gatewayv1.HTTPPathMatch{
 											Type:  &gPathPrefix,
@@ -537,7 +534,6 @@ func Test_ToIR(t *testing.T) {
 								},
 								Hostnames: []gatewayv1.Hostname{"bar.example.com"},
 								Rules: []gatewayv1.HTTPRouteRule{{
-									Name: ptrTo(gatewayv1.SectionName("rule-0")),
 									Matches: []gatewayv1.HTTPRouteMatch{{
 										Path: &gatewayv1.HTTPPathMatch{
 											Type:  &gPathPrefix,
@@ -570,7 +566,6 @@ func Test_ToIR(t *testing.T) {
 								Hostnames: []gatewayv1.Hostname{"foo.example.com"},
 								Rules: []gatewayv1.HTTPRouteRule{
 									{
-										Name: ptrTo(gatewayv1.SectionName("rule-0")),
 										Matches: []gatewayv1.HTTPRouteMatch{{
 											Path: &gatewayv1.HTTPPathMatch{
 												Type:  &gPathPrefix,
@@ -589,7 +584,6 @@ func Test_ToIR(t *testing.T) {
 										},
 									},
 									{
-										Name: ptrTo(gatewayv1.SectionName("rule-1")),
 										Matches: []gatewayv1.HTTPRouteMatch{{
 											Path: &gatewayv1.HTTPPathMatch{
 												Type:  &gPathPrefix,
@@ -752,7 +746,6 @@ func Test_ToIR(t *testing.T) {
 								},
 								Hostnames: []gatewayv1.Hostname{"bar.example.com"},
 								Rules: []gatewayv1.HTTPRouteRule{{
-									Name: ptrTo(gatewayv1.SectionName("rule-0")),
 									Matches: []gatewayv1.HTTPRouteMatch{{
 										Path: &gatewayv1.HTTPPathMatch{
 											Type:  &gPathPrefix,
@@ -795,7 +788,6 @@ func Test_ToIR(t *testing.T) {
 								Hostnames: []gatewayv1.Hostname{"foo.example.com"},
 								Rules: []gatewayv1.HTTPRouteRule{
 									{
-										Name: ptrTo(gatewayv1.SectionName("rule-0")),
 										Matches: []gatewayv1.HTTPRouteMatch{{
 											Path: &gatewayv1.HTTPPathMatch{
 												Type:  &gPathPrefix,
@@ -814,7 +806,6 @@ func Test_ToIR(t *testing.T) {
 										},
 									},
 									{
-										Name: ptrTo(gatewayv1.SectionName("rule-1")),
 										Matches: []gatewayv1.HTTPRouteMatch{{
 											Path: &gatewayv1.HTTPPathMatch{
 												Type:  &gPathPrefix,
@@ -954,7 +945,6 @@ func Test_ToIR(t *testing.T) {
 								Hostnames: []gatewayv1.Hostname{"api.example.com"},
 								Rules: []gatewayv1.HTTPRouteRule{
 									{
-										Name: ptrTo(gatewayv1.SectionName("rule-0")),
 										Matches: []gatewayv1.HTTPRouteMatch{{
 											Path: &gatewayv1.HTTPPathMatch{
 												Type:  &gPathPrefix,
@@ -984,7 +974,6 @@ func Test_ToIR(t *testing.T) {
 										},
 									},
 									{
-										Name: ptrTo(gatewayv1.SectionName("rule-1")),
 										Matches: []gatewayv1.HTTPRouteMatch{{
 											Path: &gatewayv1.HTTPPathMatch{
 												Type:  &gPathPrefix,

--- a/pkg/i2gw/providers/ingressnginx/converter_test.go
+++ b/pkg/i2gw/providers/ingressnginx/converter_test.go
@@ -1084,7 +1084,6 @@ func Test_ToIR(t *testing.T) {
 									ParentRefs: []gatewayv1.ParentReference{{Name: "nginx"}},
 								},
 								Rules: []gatewayv1.HTTPRouteRule{{
-									Name: ptrTo(gatewayv1.SectionName("rule-0")),
 									Matches: []gatewayv1.HTTPRouteMatch{{
 										Path: &gatewayv1.HTTPPathMatch{
 											Type:  &gPathPrefix,

--- a/pkg/i2gw/providers/kong/converter_test.go
+++ b/pkg/i2gw/providers/kong/converter_test.go
@@ -110,7 +110,6 @@ func Test_ToGateway(t *testing.T) {
 								},
 								Hostnames: []gatewayv1.Hostname{"test.mydomain.com"},
 								Rules: []gatewayv1.HTTPRouteRule{{
-									Name: ptrTo(gatewayv1.SectionName("rule-0")),
 									Matches: []gatewayv1.HTTPRouteMatch{
 										{
 											Path: &gatewayv1.HTTPPathMatch{
@@ -247,7 +246,6 @@ func Test_ToGateway(t *testing.T) {
 								Hostnames: []gatewayv1.Hostname{"test.mydomain.com"},
 								Rules: []gatewayv1.HTTPRouteRule{
 									{
-										Name: ptrTo(gatewayv1.SectionName("rule-0")),
 										Matches: []gatewayv1.HTTPRouteMatch{
 											{
 												Path: &gatewayv1.HTTPPathMatch{
@@ -288,7 +286,6 @@ func Test_ToGateway(t *testing.T) {
 										},
 									},
 									{
-										Name: ptrTo(gatewayv1.SectionName("rule-1")),
 										Matches: []gatewayv1.HTTPRouteMatch{
 											{
 												Path: &gatewayv1.HTTPPathMatch{
@@ -398,7 +395,6 @@ func Test_ToGateway(t *testing.T) {
 								Hostnames: []gatewayv1.Hostname{"test.mydomain.com"},
 								Rules: []gatewayv1.HTTPRouteRule{
 									{
-										Name: ptrTo(gatewayv1.SectionName("rule-0")),
 										Matches: []gatewayv1.HTTPRouteMatch{
 											{
 												Path: &gatewayv1.HTTPPathMatch{
@@ -488,7 +484,6 @@ func Test_ToGateway(t *testing.T) {
 								Hostnames: []gatewayv1.Hostname{"test.mydomain.com"},
 								Rules: []gatewayv1.HTTPRouteRule{
 									{
-										Name: ptrTo(gatewayv1.SectionName("rule-0")),
 										Matches: []gatewayv1.HTTPRouteMatch{
 											{
 												Path: &gatewayv1.HTTPPathMatch{


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/ingress2gateway/blob/main/CONTRIBUTING.md). -->

<!-- The release notes and the kind will be used to generate the Changelog for the release. To make sure your contribution is recognized, please label this pull request according to what type of issue you are addressing and add the release notes when necessary (see ../CONTRIBUTING.md) -->

**What type of PR is this?**
<!--
/kind bug

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

We were adding names to HTTPRoute rules in the common provider despite it being an Extended support field. This PR fixes this by moving the logic to a helper function that emitters can call. This also fixes an issue with the new rules created by the ingress-nginx feature parsers not having names, since we now add the names to the rules after at the emitter stage.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Adding names to HTTPRoute rules only happens in supported emitters
```
