### PR TITLE
fix: keep PathPrefix when rewrite-target is static path

### DIFF
--- a/pkg/i2gw/providers/ingressnginx/regex.go
+++ b/pkg/i2gw/providers/ingressnginx/regex.go
@@ -28,6 +28,18 @@ import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
+// pathContainsRegex returns true if the path contains regex metacharacters,
+// indicating it should be treated as a regular expression.
+func pathContainsRegex(path string) bool {
+	for _, c := range path {
+		switch c {
+		case '.', '+', '*', '?', '^', '$', '{', '}', '(', ')', '[', ']', '|', '\\':
+			return true
+		}
+	}
+	return false
+}
+
 func regexHosts(ingresses []networkingv1.Ingress) map[string]struct{} {
 	hostsWithRegex := make(map[string]struct{})
 
@@ -41,6 +53,31 @@ func regexHosts(ingresses []networkingv1.Ingress) map[string]struct{} {
 		hasRewriteTarget := ingress.Annotations[RewriteTargetAnnotation] != ""
 		if !useRegex && !hasRewriteTarget {
 			continue
+		}
+
+		// When rewrite-target is set without use-regex, only flag the host
+		// if at least one path actually contains regex metacharacters.
+		// A static rewrite-target (e.g. "/") with a plain path does not
+		// imply regex matching.
+		if !useRegex && hasRewriteTarget {
+			hasRegexPath := false
+			for _, rule := range ingress.Spec.Rules {
+				if rule.HTTP == nil {
+					continue
+				}
+				for _, p := range rule.HTTP.Paths {
+					if pathContainsRegex(p.Path) {
+						hasRegexPath = true
+						break
+					}
+				}
+				if hasRegexPath {
+					break
+				}
+			}
+			if !hasRegexPath {
+				continue
+			}
 		}
 
 		for _, rule := range ingress.Spec.Rules {

--- a/pkg/i2gw/providers/ingressnginx/regex_test.go
+++ b/pkg/i2gw/providers/ingressnginx/regex_test.go
@@ -123,7 +123,50 @@ func TestRegexFeature(t *testing.T) {
 			},
 		},
 		{
-			name: "Should map to RegularExpression when rewrite-target annotation is set",
+			name: "Should keep PathPrefix when path has no regex metacharacters",
+			ingress: networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "rewrite-static-ingress",
+					Namespace: "default",
+					Annotations: map[string]string{
+						RewriteTargetAnnotation: "/after/rewrite",
+					},
+				},
+				Spec: networkingv1.IngressSpec{
+					Rules: []networkingv1.IngressRule{
+						{
+							Host: "example.com",
+							IngressRuleValue: networkingv1.IngressRuleValue{
+								HTTP: &networkingv1.HTTPIngressRuleValue{
+									Paths: []networkingv1.HTTPIngressPath{
+										{
+											Path:     "/before/rewrite",
+											PathType: ptr.To(networkingv1.PathTypePrefix),
+											Backend: networkingv1.IngressBackend{
+												Service: &networkingv1.IngressServiceBackend{
+													Name: "service1",
+													Port: networkingv1.ServiceBackendPort{Number: 80},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: []gatewayv1.HTTPRouteMatch{
+				{
+					Path: &gatewayv1.HTTPPathMatch{
+						Type:  &prefixType,
+						Value: ptr.To("/before/rewrite"),
+					},
+				},
+			},
+		},
+		{
+			name: "Should map to RegularExpression when path contains regex metacharacters",
 			ingress: networkingv1.Ingress{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "rewrite-regex-ingress",


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/ingress2gateway/blob/main/CONTRIBUTING.md). -->

<!-- The release notes and the kind will be used to generate the Changelog for the release. To make sure your contribution is recognized, please label this pull request according to what type of issue you are addressing and add the release notes when necessary (see ../CONTRIBUTING.md) -->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

fix bug in regex logic. if rewrite-target is static path should not treat as regex.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
fix: keep PathPrefix when rewrite-target is static path
```
