### PR TITLE
feat(gce): Add Cloud CDN support via GCPHTTPFilter

### DIFF
--- a/pkg/i2gw/emitter_intermediate/gce/gce.go
+++ b/pkg/i2gw/emitter_intermediate/gce/gce.go
@@ -51,16 +51,16 @@ type CdnConfig struct {
 }
 
 type CachePolicy struct {
-	CacheKeyPolicy              *CacheKeyPolicy              `json:"cacheKeyPolicy,omitempty"`
-	RequestCoalescing           *bool                        `json:"requestCoalescing,omitempty"`
-	CacheMode                   string                       `json:"cacheMode,omitempty"`
-	DefaultTTL                  string                       `json:"defaultTTL,omitempty"`
-	MaxTTL                      string                       `json:"maxTTL,omitempty"`
-	ClientTTL                   string                       `json:"clientTTL,omitempty"`
-	NegativeCaching             *bool                        `json:"negativeCaching,omitempty"`
-	NegativeCachingPolicy       []NegativeCachingPolicy      `json:"negativeCachingPolicy,omitempty"`
-	BypassCacheOnRequestHeaders []BypassCacheOnRequestHeader `json:"bypassCacheOnRequestHeaders,omitempty"`
-	ServeWhileStale             string                       `json:"serveWhileStale,omitempty"`
+	CacheKeyPolicy                *CacheKeyPolicy         `json:"cacheKeyPolicy,omitempty"`
+	RequestCoalescing             *bool                   `json:"requestCoalescing,omitempty"`
+	CacheMode                     string                  `json:"cacheMode,omitempty"`
+	DefaultTTL                    string                  `json:"defaultTTL,omitempty"`
+	MaxTTL                        string                  `json:"maxTTL,omitempty"`
+	ClientTTL                     string                  `json:"clientTTL,omitempty"`
+	NegativeCaching               *bool                   `json:"negativeCaching,omitempty"`
+	NegativeCachingPolicy         []NegativeCachingPolicy `json:"negativeCachingPolicy,omitempty"`
+	CacheBypassRequestHeaderNames []string                `json:"cacheBypassRequestHeaderNames,omitempty"`
+	ServeWhileStale               string                  `json:"serveWhileStale,omitempty"`
 }
 
 type CacheKeyPolicy struct {
@@ -76,8 +76,4 @@ type CacheKeyPolicy struct {
 type NegativeCachingPolicy struct {
 	Code int    `json:"code"`
 	TTL  string `json:"ttl"`
-}
-
-type BypassCacheOnRequestHeader struct {
-	HeaderName string `json:"headerName,omitempty"`
 }

--- a/pkg/i2gw/emitter_intermediate/gce/gce.go
+++ b/pkg/i2gw/emitter_intermediate/gce/gce.go
@@ -27,6 +27,7 @@ type ServiceIR struct {
 	SessionAffinity *SessionAffinityConfig
 	SecurityPolicy  *SecurityPolicyConfig
 	HealthCheck     *HealthCheckConfig
+	Cdn             *CdnConfig
 }
 type SessionAffinityConfig struct {
 	AffinityType string
@@ -43,4 +44,40 @@ type HealthCheckConfig struct {
 	Type               *string
 	Port               *int64
 	RequestPath        *string
+}
+
+type CdnConfig struct {
+	CachePolicy *CachePolicy `json:"cachePolicy,omitempty"`
+}
+
+type CachePolicy struct {
+	CacheKeyPolicy                *CacheKeyPolicy              `json:"cacheKeyPolicy,omitempty"`
+	RequestCoalescing             *bool                        `json:"requestCoalescing,omitempty"`
+	CacheMode                     string                       `json:"cacheMode,omitempty"`
+	DefaultTTL                    string                       `json:"defaultTTL,omitempty"`
+	MaxTTL                        string                       `json:"maxTTL,omitempty"`
+	ClientTTL                     string                       `json:"clientTTL,omitempty"`
+	NegativeCaching               *bool                        `json:"negativeCaching,omitempty"`
+	NegativeCachingPolicy         []NegativeCachingPolicy      `json:"negativeCachingPolicy,omitempty"`
+	CacheBypassRequestHeaderNames []BypassCacheOnRequestHeader `json:"cacheBypassRequestHeaderNames,omitempty"`
+	ServeWhileStale               string                       `json:"serveWhileStale,omitempty"`
+}
+
+type CacheKeyPolicy struct {
+	IncludeProtocol         *bool    `json:"includeProtocol,omitempty"`
+	IncludeHost             *bool    `json:"includeHost,omitempty"`
+	IncludeQueryString      *bool    `json:"includeQueryString,omitempty"`
+	ExcludedQueryParameters []string `json:"excludedQueryParameters,omitempty"`
+	IncludedQueryParameters []string `json:"includedQueryParameters,omitempty"`
+	IncludedHeaderNames     []string `json:"includedHeaderNames,omitempty"`
+	IncludedCookieNames     []string `json:"includedCookieNames,omitempty"`
+}
+
+type NegativeCachingPolicy struct {
+	Code int    `json:"code"`
+	TTL  string `json:"ttl"`
+}
+
+type BypassCacheOnRequestHeader struct {
+	CacheBypassRequestHeaderNames []string `json:"cacheBypassRequestHeaderNames,omitempty"`
 }

--- a/pkg/i2gw/emitter_intermediate/gce/gce.go
+++ b/pkg/i2gw/emitter_intermediate/gce/gce.go
@@ -51,16 +51,16 @@ type CdnConfig struct {
 }
 
 type CachePolicy struct {
-	CacheKeyPolicy                *CacheKeyPolicy              `json:"cacheKeyPolicy,omitempty"`
-	RequestCoalescing             *bool                        `json:"requestCoalescing,omitempty"`
-	CacheMode                     string                       `json:"cacheMode,omitempty"`
-	DefaultTTL                    string                       `json:"defaultTTL,omitempty"`
-	MaxTTL                        string                       `json:"maxTTL,omitempty"`
-	ClientTTL                     string                       `json:"clientTTL,omitempty"`
-	NegativeCaching               *bool                        `json:"negativeCaching,omitempty"`
-	NegativeCachingPolicy         []NegativeCachingPolicy      `json:"negativeCachingPolicy,omitempty"`
-	CacheBypassRequestHeaderNames []BypassCacheOnRequestHeader `json:"cacheBypassRequestHeaderNames,omitempty"`
-	ServeWhileStale               string                       `json:"serveWhileStale,omitempty"`
+	CacheKeyPolicy              *CacheKeyPolicy              `json:"cacheKeyPolicy,omitempty"`
+	RequestCoalescing           *bool                        `json:"requestCoalescing,omitempty"`
+	CacheMode                   string                       `json:"cacheMode,omitempty"`
+	DefaultTTL                  string                       `json:"defaultTTL,omitempty"`
+	MaxTTL                      string                       `json:"maxTTL,omitempty"`
+	ClientTTL                   string                       `json:"clientTTL,omitempty"`
+	NegativeCaching             *bool                        `json:"negativeCaching,omitempty"`
+	NegativeCachingPolicy       []NegativeCachingPolicy      `json:"negativeCachingPolicy,omitempty"`
+	BypassCacheOnRequestHeaders []BypassCacheOnRequestHeader `json:"bypassCacheOnRequestHeaders,omitempty"`
+	ServeWhileStale             string                       `json:"serveWhileStale,omitempty"`
 }
 
 type CacheKeyPolicy struct {
@@ -79,5 +79,5 @@ type NegativeCachingPolicy struct {
 }
 
 type BypassCacheOnRequestHeader struct {
-	CacheBypassRequestHeaderNames []string `json:"cacheBypassRequestHeaderNames,omitempty"`
+	HeaderName string `json:"headerName,omitempty"`
 }

--- a/pkg/i2gw/emitters/gce/gce.go
+++ b/pkg/i2gw/emitters/gce/gce.go
@@ -23,6 +23,7 @@ import (
 	"github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw/emitter_intermediate/gce"
 	"github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw/emitters/utils"
 	"github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw/notifications"
+	providergce "github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw/providers/gce"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -50,6 +51,12 @@ var (
 		Group:   "networking.gke.io",
 		Version: "v1",
 		Kind:    "HealthCheckPolicy",
+	}
+
+	GCPHTTPFilterGVK = schema.GroupVersionKind{
+		Group:   "networking.gke.io",
+		Version: "v1",
+		Kind:    "GCPHTTPFilter",
 	}
 )
 
@@ -173,6 +180,16 @@ func buildGceServiceExtensions(notify notifications.NotifyFunc, ir emitterir.Emi
 			}
 			gatewayResources.GatewayExtensions = append(gatewayResources.GatewayExtensions, *obj)
 		}
+
+		httpFilter := addGCPHTTPFilterIfConfigured(svcKey, gceServiceIR)
+		if httpFilter != nil {
+			obj, err := i2gw.CastToUnstructured(httpFilter)
+			if err != nil {
+				notify(notifications.ErrorNotification, "Failed to cast GCPHTTPFilter to unstructured", httpFilter)
+				continue
+			}
+			gatewayResources.GatewayExtensions = append(gatewayResources.GatewayExtensions, *obj)
+		}
 	}
 }
 
@@ -245,4 +262,22 @@ func addHealthCheckPolicyIfConfigured(serviceNamespacedName types.NamespacedName
 	}
 	healthCheckPolicy.SetGroupVersionKind(HealthCheckPolicyGVK)
 	return &healthCheckPolicy
+}
+
+func addGCPHTTPFilterIfConfigured(serviceNamespacedName types.NamespacedName, gceServiceIR *gce.ServiceIR) *providergce.GCPHTTPFilter {
+	if gceServiceIR == nil || gceServiceIR.Cdn == nil {
+		return nil
+	}
+
+	httpFilter := providergce.GCPHTTPFilter{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: serviceNamespacedName.Namespace,
+			Name:      serviceNamespacedName.Name,
+		},
+		Spec: providergce.GCPHTTPFilterSpec{
+			CachePolicy: gceServiceIR.Cdn.CachePolicy,
+		},
+	}
+	httpFilter.SetGroupVersionKind(GCPHTTPFilterGVK)
+	return &httpFilter
 }

--- a/pkg/i2gw/emitters/gce/gce.go
+++ b/pkg/i2gw/emitters/gce/gce.go
@@ -81,6 +81,7 @@ func (c *Emitter) Emit(ir emitterir.EmitterIR) (i2gw.GatewayResources, field.Err
 	}
 	buildGceGatewayExtensions(c.notify, ir, &gatewayResources)
 	buildGceServiceExtensions(c.notify, ir, &gatewayResources)
+	patchHTTPRoutesWithFilters(ir, &gatewayResources)
 
 	removeHTTPRouteRuleNames(&gatewayResources)
 	return gatewayResources, nil
@@ -280,4 +281,49 @@ func addGCPHTTPFilterIfConfigured(serviceNamespacedName types.NamespacedName, gc
 	}
 	httpFilter.SetGroupVersionKind(GCPHTTPFilterGVK)
 	return &httpFilter
+}
+
+func patchHTTPRoutesWithFilters(ir emitterir.EmitterIR, gatewayResources *i2gw.GatewayResources) {
+	for routeKey, route := range gatewayResources.HTTPRoutes {
+		for i := range route.Spec.Rules {
+			for j := range route.Spec.Rules[i].BackendRefs {
+				backendRef := route.Spec.Rules[i].BackendRefs[j]
+				if backendRef.Name == "" {
+					continue
+				}
+				svcKey := types.NamespacedName{Namespace: routeKey.Namespace, Name: string(backendRef.Name)}
+				gceSvc, exists := ir.GceServices[svcKey]
+				if !exists || gceSvc.Cdn == nil {
+					continue
+				}
+				// Found a backend with CDN enabled!
+				// Attach the filter to the HTTPRoute rule.
+				filter := gatewayv1.HTTPRouteFilter{
+					Type: gatewayv1.HTTPRouteFilterExtensionRef,
+					ExtensionRef: &gatewayv1.LocalObjectReference{
+						Group: "networking.gke.io",
+						Kind:  "GCPHTTPFilter",
+						Name:  gatewayv1.ObjectName(string(backendRef.Name) + "-filter"),
+					},
+				}
+				if route.Spec.Rules[i].Filters == nil {
+					route.Spec.Rules[i].Filters = make([]gatewayv1.HTTPRouteFilter, 0)
+				}
+				// Avoid adding duplicate filters
+				alreadyExists := false
+				for _, existingFilter := range route.Spec.Rules[i].Filters {
+					if existingFilter.Type == gatewayv1.HTTPRouteFilterExtensionRef &&
+						existingFilter.ExtensionRef != nil &&
+						existingFilter.ExtensionRef.Name == filter.ExtensionRef.Name {
+						alreadyExists = true
+						break
+					}
+				}
+				if !alreadyExists {
+					route.Spec.Rules[i].Filters = append(route.Spec.Rules[i].Filters, filter)
+				}
+			}
+		}
+		gatewayResources.HTTPRoutes[routeKey] = route
+	}
 }

--- a/pkg/i2gw/emitters/gce/gce.go
+++ b/pkg/i2gw/emitters/gce/gce.go
@@ -272,7 +272,7 @@ func addGCPHTTPFilterIfConfigured(serviceNamespacedName types.NamespacedName, gc
 	httpFilter := providergce.GCPHTTPFilter{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: serviceNamespacedName.Namespace,
-			Name:      serviceNamespacedName.Name,
+			Name:      serviceNamespacedName.Name + "-filter",
 		},
 		Spec: providergce.GCPHTTPFilterSpec{
 			CachePolicy: gceServiceIR.Cdn.CachePolicy,

--- a/pkg/i2gw/emitters/gce/gce_test.go
+++ b/pkg/i2gw/emitters/gce/gce_test.go
@@ -200,6 +200,22 @@ var (
 			},
 		},
 	}
+
+	testGCPHTTPFilterUnstructured = &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "networking.gke.io/v1",
+			"kind":       "GCPHTTPFilter",
+			"metadata": map[string]interface{}{
+				"namespace": testNamespace,
+				"name":      testServiceName + "-filter",
+			},
+			"spec": map[string]interface{}{
+				"cachePolicy": map[string]interface{}{
+					"cacheMode": "USE_ORIGIN_HEADERS",
+				},
+			},
+		},
+	}
 )
 
 func Test_irToGateway(t *testing.T) {
@@ -475,6 +491,84 @@ func Test_irToGateway(t *testing.T) {
 				},
 				GatewayExtensions: []unstructured.Unstructured{
 					getTestHealthCheckPolicyUnstrctured(testNamespace, testServiceName, protocolHTTP2),
+				},
+			},
+			expectedErrors: field.ErrorList{},
+		},
+		{
+			name: "ingress with a Backend Config specifying Cloud CDN",
+			ir: emitterir.EmitterIR{
+				Gateways: map[types.NamespacedName]emitterir.GatewayContext{
+					{Namespace: testNamespace, Name: testGatewayName}: {
+						Gateway: testGateway,
+					},
+				},
+				HTTPRoutes: map[types.NamespacedName]emitterir.HTTPRouteContext{
+					{Namespace: testNamespace, Name: testHTTPRouteName}: {
+						HTTPRoute: testHTTPRoute,
+					},
+				},
+				GceServices: map[types.NamespacedName]gce.ServiceIR{
+					{Namespace: testNamespace, Name: testServiceName}: {
+						Cdn: &gce.CdnConfig{
+							CachePolicy: &gce.CachePolicy{
+								CacheMode: "USE_ORIGIN_HEADERS",
+							},
+						},
+					},
+				},
+			},
+			expectedGatewayResources: i2gw.GatewayResources{
+				Gateways: map[types.NamespacedName]gatewayv1.Gateway{
+					{Namespace: testNamespace, Name: testGatewayName}: testGateway,
+				},
+				HTTPRoutes: map[types.NamespacedName]gatewayv1.HTTPRoute{
+					{Namespace: testNamespace, Name: testHTTPRouteName}: {
+						ObjectMeta: metav1.ObjectMeta{Name: testHTTPRouteName, Namespace: testNamespace},
+						Spec: gatewayv1.HTTPRouteSpec{
+							CommonRouteSpec: gatewayv1.CommonRouteSpec{
+								ParentRefs: []gatewayv1.ParentReference{{
+									Name: gatewayv1.ObjectName(testGatewayName),
+								}},
+							},
+							Hostnames: []gatewayv1.Hostname{gatewayv1.Hostname(testHost)},
+							Rules: []gatewayv1.HTTPRouteRule{
+								{
+									Matches: []gatewayv1.HTTPRouteMatch{
+										{
+											Path: &gatewayv1.HTTPPathMatch{
+												Type:  common.PtrTo(gPathPrefix),
+												Value: common.PtrTo("/"),
+											},
+										},
+									},
+									BackendRefs: []gatewayv1.HTTPBackendRef{
+										{
+											BackendRef: gatewayv1.BackendRef{
+												BackendObjectReference: gatewayv1.BackendObjectReference{
+													Name: gatewayv1.ObjectName(testServiceName),
+													Port: common.PtrTo(gatewayv1.PortNumber(80)),
+												},
+											},
+										},
+									},
+									Filters: []gatewayv1.HTTPRouteFilter{
+										{
+											Type: gatewayv1.HTTPRouteFilterExtensionRef,
+											ExtensionRef: &gatewayv1.LocalObjectReference{
+												Group: "networking.gke.io",
+												Kind:  "GCPHTTPFilter",
+												Name:  gatewayv1.ObjectName(testServiceName + "-filter"),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				GatewayExtensions: []unstructured.Unstructured{
+					*testGCPHTTPFilterUnstructured,
 				},
 			},
 			expectedErrors: field.ErrorList{},

--- a/pkg/i2gw/providers/gce/extensions/input_extensions.go
+++ b/pkg/i2gw/providers/gce/extensions/input_extensions.go
@@ -90,3 +90,34 @@ func BuildIRHealthCheckConfig(beConfig *backendconfigv1.BackendConfig) *gce.Heal
 		RequestPath:        beConfig.Spec.HealthCheck.RequestPath,
 	}
 }
+
+func BuildIRCdnConfig(beConfig *backendconfigv1.BackendConfig) *gce.CdnConfig {
+	if beConfig.Spec.Cdn == nil {
+		return nil
+	}
+	return &gce.CdnConfig{
+		CachePolicy: &gce.CachePolicy{
+			CacheMode:         stringPtrToString(beConfig.Spec.Cdn.CacheMode),
+			DefaultTTL:        int64PtrToDurationString(beConfig.Spec.Cdn.DefaultTtl),
+			MaxTTL:            int64PtrToDurationString(beConfig.Spec.Cdn.MaxTtl),
+			ClientTTL:         int64PtrToDurationString(beConfig.Spec.Cdn.ClientTtl),
+			RequestCoalescing: beConfig.Spec.Cdn.RequestCoalescing,
+			ServeWhileStale:   int64PtrToDurationString(beConfig.Spec.Cdn.ServeWhileStale),
+			NegativeCaching:   beConfig.Spec.Cdn.NegativeCaching,
+		},
+	}
+}
+
+func stringPtrToString(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}
+
+func int64PtrToDurationString(i *int64) string {
+	if i == nil {
+		return ""
+	}
+	return fmt.Sprintf("%ds", *i)
+}

--- a/pkg/i2gw/providers/gce/extensions/input_extensions.go
+++ b/pkg/i2gw/providers/gce/extensions/input_extensions.go
@@ -95,15 +95,25 @@ func BuildIRCdnConfig(beConfig *backendconfigv1.BackendConfig) *gce.CdnConfig {
 	if beConfig.Spec.Cdn == nil {
 		return nil
 	}
+	var bypassHeaders []gce.BypassCacheOnRequestHeader
+	for _, h := range beConfig.Spec.Cdn.BypassCacheOnRequestHeaders {
+		if h != nil {
+			bypassHeaders = append(bypassHeaders, gce.BypassCacheOnRequestHeader{
+				HeaderName: h.HeaderName,
+			})
+		}
+	}
+
 	return &gce.CdnConfig{
 		CachePolicy: &gce.CachePolicy{
-			CacheMode:         stringPtrToString(beConfig.Spec.Cdn.CacheMode),
-			DefaultTTL:        int64PtrToDurationString(beConfig.Spec.Cdn.DefaultTtl),
-			MaxTTL:            int64PtrToDurationString(beConfig.Spec.Cdn.MaxTtl),
-			ClientTTL:         int64PtrToDurationString(beConfig.Spec.Cdn.ClientTtl),
-			RequestCoalescing: beConfig.Spec.Cdn.RequestCoalescing,
-			ServeWhileStale:   int64PtrToDurationString(beConfig.Spec.Cdn.ServeWhileStale),
-			NegativeCaching:   beConfig.Spec.Cdn.NegativeCaching,
+			CacheMode:                   stringPtrToString(beConfig.Spec.Cdn.CacheMode),
+			DefaultTTL:                  int64PtrToDurationString(beConfig.Spec.Cdn.DefaultTtl),
+			MaxTTL:                      int64PtrToDurationString(beConfig.Spec.Cdn.MaxTtl),
+			ClientTTL:                   int64PtrToDurationString(beConfig.Spec.Cdn.ClientTtl),
+			RequestCoalescing:           beConfig.Spec.Cdn.RequestCoalescing,
+			ServeWhileStale:             int64PtrToDurationString(beConfig.Spec.Cdn.ServeWhileStale),
+			NegativeCaching:             beConfig.Spec.Cdn.NegativeCaching,
+			BypassCacheOnRequestHeaders: bypassHeaders,
 		},
 	}
 }

--- a/pkg/i2gw/providers/gce/extensions/input_extensions.go
+++ b/pkg/i2gw/providers/gce/extensions/input_extensions.go
@@ -95,25 +95,23 @@ func BuildIRCdnConfig(beConfig *backendconfigv1.BackendConfig) *gce.CdnConfig {
 	if beConfig.Spec.Cdn == nil {
 		return nil
 	}
-	var bypassHeaders []gce.BypassCacheOnRequestHeader
+	var bypassHeaders []string
 	for _, h := range beConfig.Spec.Cdn.BypassCacheOnRequestHeaders {
 		if h != nil {
-			bypassHeaders = append(bypassHeaders, gce.BypassCacheOnRequestHeader{
-				HeaderName: h.HeaderName,
-			})
+			bypassHeaders = append(bypassHeaders, h.HeaderName)
 		}
 	}
 
 	return &gce.CdnConfig{
 		CachePolicy: &gce.CachePolicy{
-			CacheMode:                   stringPtrToString(beConfig.Spec.Cdn.CacheMode),
-			DefaultTTL:                  int64PtrToDurationString(beConfig.Spec.Cdn.DefaultTtl),
-			MaxTTL:                      int64PtrToDurationString(beConfig.Spec.Cdn.MaxTtl),
-			ClientTTL:                   int64PtrToDurationString(beConfig.Spec.Cdn.ClientTtl),
-			RequestCoalescing:           beConfig.Spec.Cdn.RequestCoalescing,
-			ServeWhileStale:             int64PtrToDurationString(beConfig.Spec.Cdn.ServeWhileStale),
-			NegativeCaching:             beConfig.Spec.Cdn.NegativeCaching,
-			BypassCacheOnRequestHeaders: bypassHeaders,
+			CacheMode:                     stringPtrToString(beConfig.Spec.Cdn.CacheMode),
+			DefaultTTL:                    int64PtrToDurationString(beConfig.Spec.Cdn.DefaultTtl),
+			MaxTTL:                        int64PtrToDurationString(beConfig.Spec.Cdn.MaxTtl),
+			ClientTTL:                     int64PtrToDurationString(beConfig.Spec.Cdn.ClientTtl),
+			RequestCoalescing:             beConfig.Spec.Cdn.RequestCoalescing,
+			ServeWhileStale:               int64PtrToDurationString(beConfig.Spec.Cdn.ServeWhileStale),
+			NegativeCaching:               beConfig.Spec.Cdn.NegativeCaching,
+			CacheBypassRequestHeaderNames: bypassHeaders,
 		},
 	}
 }

--- a/pkg/i2gw/providers/gce/extensions/input_extensions.go
+++ b/pkg/i2gw/providers/gce/extensions/input_extensions.go
@@ -92,7 +92,7 @@ func BuildIRHealthCheckConfig(beConfig *backendconfigv1.BackendConfig) *gce.Heal
 }
 
 func BuildIRCdnConfig(beConfig *backendconfigv1.BackendConfig) *gce.CdnConfig {
-	if beConfig.Spec.Cdn == nil {
+	if beConfig.Spec.Cdn == nil || !beConfig.Spec.Cdn.Enabled {
 		return nil
 	}
 	var bypassHeaders []string
@@ -102,8 +102,30 @@ func BuildIRCdnConfig(beConfig *backendconfigv1.BackendConfig) *gce.CdnConfig {
 		}
 	}
 
+	var cacheKeyPolicy *gce.CacheKeyPolicy
+	if beConfig.Spec.Cdn.CachePolicy != nil {
+		cacheKeyPolicy = &gce.CacheKeyPolicy{
+			IncludeHost:             boolPtr(beConfig.Spec.Cdn.CachePolicy.IncludeHost),
+			IncludeProtocol:         boolPtr(beConfig.Spec.Cdn.CachePolicy.IncludeProtocol),
+			IncludeQueryString:      boolPtr(beConfig.Spec.Cdn.CachePolicy.IncludeQueryString),
+			ExcludedQueryParameters: beConfig.Spec.Cdn.CachePolicy.QueryStringBlacklist,
+			IncludedQueryParameters: beConfig.Spec.Cdn.CachePolicy.QueryStringWhitelist,
+		}
+	}
+
+	var negativeCachingPolicy []gce.NegativeCachingPolicy
+	for _, p := range beConfig.Spec.Cdn.NegativeCachingPolicy {
+		if p != nil {
+			negativeCachingPolicy = append(negativeCachingPolicy, gce.NegativeCachingPolicy{
+				Code: int(p.Code),
+				TTL:  fmt.Sprintf("%ds", p.Ttl),
+			})
+		}
+	}
+
 	return &gce.CdnConfig{
 		CachePolicy: &gce.CachePolicy{
+			CacheKeyPolicy:                cacheKeyPolicy,
 			CacheMode:                     stringPtrToString(beConfig.Spec.Cdn.CacheMode),
 			DefaultTTL:                    int64PtrToDurationString(beConfig.Spec.Cdn.DefaultTtl),
 			MaxTTL:                        int64PtrToDurationString(beConfig.Spec.Cdn.MaxTtl),
@@ -111,6 +133,7 @@ func BuildIRCdnConfig(beConfig *backendconfigv1.BackendConfig) *gce.CdnConfig {
 			RequestCoalescing:             beConfig.Spec.Cdn.RequestCoalescing,
 			ServeWhileStale:               int64PtrToDurationString(beConfig.Spec.Cdn.ServeWhileStale),
 			NegativeCaching:               beConfig.Spec.Cdn.NegativeCaching,
+			NegativeCachingPolicy:         negativeCachingPolicy,
 			CacheBypassRequestHeaderNames: bypassHeaders,
 		},
 	}
@@ -128,4 +151,8 @@ func int64PtrToDurationString(i *int64) string {
 		return ""
 	}
 	return fmt.Sprintf("%ds", *i)
+}
+
+func boolPtr(b bool) *bool {
+	return &b
 }

--- a/pkg/i2gw/providers/gce/extensions/input_extensions_test.go
+++ b/pkg/i2gw/providers/gce/extensions/input_extensions_test.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package extensions
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw/emitter_intermediate/gce"
+	backendconfigv1 "k8s.io/ingress-gce/pkg/apis/backendconfig/v1"
+)
+
+func TestBuildIRCdnConfig(t *testing.T) {
+	tests := []struct {
+		name     string
+		beConfig *backendconfigv1.BackendConfig
+		want     *gce.CdnConfig
+	}{
+		{
+			name:     "nil cdn config",
+			beConfig: &backendconfigv1.BackendConfig{Spec: backendconfigv1.BackendConfigSpec{}},
+			want:     nil,
+		},
+		{
+			name: "disabled cdn config",
+			beConfig: &backendconfigv1.BackendConfig{
+				Spec: backendconfigv1.BackendConfigSpec{
+					Cdn: &backendconfigv1.CDNConfig{
+						Enabled: false,
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "full cdn config",
+			beConfig: &backendconfigv1.BackendConfig{
+				Spec: backendconfigv1.BackendConfigSpec{
+					Cdn: &backendconfigv1.CDNConfig{
+						Enabled:                     true,
+						CacheMode:                   ptr("CACHE_ALL_STATIC"),
+						DefaultTtl:                  ptr(int64(3600)),
+						MaxTtl:                      ptr(int64(7200)),
+						ClientTtl:                   ptr(int64(1800)),
+						RequestCoalescing:           ptr(true),
+						ServeWhileStale:             ptr(int64(60)),
+						NegativeCaching:             ptr(true),
+						NegativeCachingPolicy:       []*backendconfigv1.NegativeCachingPolicy{{Code: 404, Ttl: 300}},
+						BypassCacheOnRequestHeaders: []*backendconfigv1.BypassCacheOnRequestHeader{{HeaderName: "x-bypass"}},
+						CachePolicy: &backendconfigv1.CacheKeyPolicy{
+							IncludeHost:          true,
+							IncludeProtocol:      true,
+							IncludeQueryString:   true,
+							QueryStringWhitelist: []string{"q"},
+						},
+					},
+				},
+			},
+			want: &gce.CdnConfig{
+				CachePolicy: &gce.CachePolicy{
+					CacheMode:                     "CACHE_ALL_STATIC",
+					DefaultTTL:                    "3600s",
+					MaxTTL:                        "7200s",
+					ClientTTL:                     "1800s",
+					RequestCoalescing:             ptr(true),
+					ServeWhileStale:               "60s",
+					NegativeCaching:               ptr(true),
+					NegativeCachingPolicy:         []gce.NegativeCachingPolicy{{Code: 404, TTL: "300s"}},
+					CacheBypassRequestHeaderNames: []string{"x-bypass"},
+					CacheKeyPolicy: &gce.CacheKeyPolicy{
+						IncludeHost:             ptr(true),
+						IncludeProtocol:         ptr(true),
+						IncludeQueryString:      ptr(true),
+						IncludedQueryParameters: []string{"q"},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := BuildIRCdnConfig(tt.beConfig)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("BuildIRCdnConfig() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func ptr[T any](v T) *T {
+	return &v
+}

--- a/pkg/i2gw/providers/gce/gcphttpfilter.go
+++ b/pkg/i2gw/providers/gce/gcphttpfilter.go
@@ -38,5 +38,18 @@ type GCPHTTPFilterSpec struct {
 func (in *GCPHTTPFilter) DeepCopyObject() runtime.Object {
 	out := new(GCPHTTPFilter)
 	*out = *in
+	if in.Spec.CachePolicy != nil {
+		out.Spec.CachePolicy = new(emittergce.CachePolicy)
+		*out.Spec.CachePolicy = *in.Spec.CachePolicy
+
+		if in.Spec.CachePolicy.RequestCoalescing != nil {
+			out.Spec.CachePolicy.RequestCoalescing = new(bool)
+			*out.Spec.CachePolicy.RequestCoalescing = *in.Spec.CachePolicy.RequestCoalescing
+		}
+		if in.Spec.CachePolicy.NegativeCaching != nil {
+			out.Spec.CachePolicy.NegativeCaching = new(bool)
+			*out.Spec.CachePolicy.NegativeCaching = *in.Spec.CachePolicy.NegativeCaching
+		}
+	}
 	return out
 }

--- a/pkg/i2gw/providers/gce/gcphttpfilter.go
+++ b/pkg/i2gw/providers/gce/gcphttpfilter.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gce
+
+import (
+	emittergce "github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw/emitter_intermediate/gce"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// GCPHTTPFilter is the CRD for Cloud CDN configuration.
+type GCPHTTPFilter struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec GCPHTTPFilterSpec `json:"spec,omitempty"`
+}
+
+type GCPHTTPFilterSpec struct {
+	CachePolicy *emittergce.CachePolicy `json:"cachePolicy,omitempty"`
+}
+
+// DeepCopyObject implements the runtime.Object interface.
+func (in *GCPHTTPFilter) DeepCopyObject() runtime.Object {
+	out := new(GCPHTTPFilter)
+	*out = *in
+	return out
+}

--- a/pkg/i2gw/providers/gce/gcphttpfilter.go
+++ b/pkg/i2gw/providers/gce/gcphttpfilter.go
@@ -38,6 +38,7 @@ type GCPHTTPFilterSpec struct {
 func (in *GCPHTTPFilter) DeepCopyObject() runtime.Object {
 	out := new(GCPHTTPFilter)
 	*out = *in
+	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
 	if in.Spec.CachePolicy != nil {
 		out.Spec.CachePolicy = new(emittergce.CachePolicy)
 		*out.Spec.CachePolicy = *in.Spec.CachePolicy
@@ -49,6 +50,35 @@ func (in *GCPHTTPFilter) DeepCopyObject() runtime.Object {
 		if in.Spec.CachePolicy.NegativeCaching != nil {
 			out.Spec.CachePolicy.NegativeCaching = new(bool)
 			*out.Spec.CachePolicy.NegativeCaching = *in.Spec.CachePolicy.NegativeCaching
+		}
+		if in.Spec.CachePolicy.CacheKeyPolicy != nil {
+			out.Spec.CachePolicy.CacheKeyPolicy = new(emittergce.CacheKeyPolicy)
+			*out.Spec.CachePolicy.CacheKeyPolicy = *in.Spec.CachePolicy.CacheKeyPolicy
+			
+			if in.Spec.CachePolicy.CacheKeyPolicy.ExcludedQueryParameters != nil {
+				out.Spec.CachePolicy.CacheKeyPolicy.ExcludedQueryParameters = make([]string, len(in.Spec.CachePolicy.CacheKeyPolicy.ExcludedQueryParameters))
+				copy(out.Spec.CachePolicy.CacheKeyPolicy.ExcludedQueryParameters, in.Spec.CachePolicy.CacheKeyPolicy.ExcludedQueryParameters)
+			}
+			if in.Spec.CachePolicy.CacheKeyPolicy.IncludedQueryParameters != nil {
+				out.Spec.CachePolicy.CacheKeyPolicy.IncludedQueryParameters = make([]string, len(in.Spec.CachePolicy.CacheKeyPolicy.IncludedQueryParameters))
+				copy(out.Spec.CachePolicy.CacheKeyPolicy.IncludedQueryParameters, in.Spec.CachePolicy.CacheKeyPolicy.IncludedQueryParameters)
+			}
+			if in.Spec.CachePolicy.CacheKeyPolicy.IncludedHeaderNames != nil {
+				out.Spec.CachePolicy.CacheKeyPolicy.IncludedHeaderNames = make([]string, len(in.Spec.CachePolicy.CacheKeyPolicy.IncludedHeaderNames))
+				copy(out.Spec.CachePolicy.CacheKeyPolicy.IncludedHeaderNames, in.Spec.CachePolicy.CacheKeyPolicy.IncludedHeaderNames)
+			}
+			if in.Spec.CachePolicy.CacheKeyPolicy.IncludedCookieNames != nil {
+				out.Spec.CachePolicy.CacheKeyPolicy.IncludedCookieNames = make([]string, len(in.Spec.CachePolicy.CacheKeyPolicy.IncludedCookieNames))
+				copy(out.Spec.CachePolicy.CacheKeyPolicy.IncludedCookieNames, in.Spec.CachePolicy.CacheKeyPolicy.IncludedCookieNames)
+			}
+		}
+		if in.Spec.CachePolicy.NegativeCachingPolicy != nil {
+			out.Spec.CachePolicy.NegativeCachingPolicy = make([]emittergce.NegativeCachingPolicy, len(in.Spec.CachePolicy.NegativeCachingPolicy))
+			copy(out.Spec.CachePolicy.NegativeCachingPolicy, in.Spec.CachePolicy.NegativeCachingPolicy)
+		}
+		if in.Spec.CachePolicy.CacheBypassRequestHeaderNames != nil {
+			out.Spec.CachePolicy.CacheBypassRequestHeaderNames = make([]string, len(in.Spec.CachePolicy.CacheBypassRequestHeaderNames))
+			copy(out.Spec.CachePolicy.CacheBypassRequestHeaderNames, in.Spec.CachePolicy.CacheBypassRequestHeaderNames)
 		}
 	}
 	return out

--- a/pkg/i2gw/providers/gce/gcphttpfilter.go
+++ b/pkg/i2gw/providers/gce/gcphttpfilter.go
@@ -55,6 +55,19 @@ func (in *GCPHTTPFilter) DeepCopyObject() runtime.Object {
 			out.Spec.CachePolicy.CacheKeyPolicy = new(emittergce.CacheKeyPolicy)
 			*out.Spec.CachePolicy.CacheKeyPolicy = *in.Spec.CachePolicy.CacheKeyPolicy
 
+			if in.Spec.CachePolicy.CacheKeyPolicy.IncludeProtocol != nil {
+				out.Spec.CachePolicy.CacheKeyPolicy.IncludeProtocol = new(bool)
+				*out.Spec.CachePolicy.CacheKeyPolicy.IncludeProtocol = *in.Spec.CachePolicy.CacheKeyPolicy.IncludeProtocol
+			}
+			if in.Spec.CachePolicy.CacheKeyPolicy.IncludeHost != nil {
+				out.Spec.CachePolicy.CacheKeyPolicy.IncludeHost = new(bool)
+				*out.Spec.CachePolicy.CacheKeyPolicy.IncludeHost = *in.Spec.CachePolicy.CacheKeyPolicy.IncludeHost
+			}
+			if in.Spec.CachePolicy.CacheKeyPolicy.IncludeQueryString != nil {
+				out.Spec.CachePolicy.CacheKeyPolicy.IncludeQueryString = new(bool)
+				*out.Spec.CachePolicy.CacheKeyPolicy.IncludeQueryString = *in.Spec.CachePolicy.CacheKeyPolicy.IncludeQueryString
+			}
+
 			if in.Spec.CachePolicy.CacheKeyPolicy.ExcludedQueryParameters != nil {
 				out.Spec.CachePolicy.CacheKeyPolicy.ExcludedQueryParameters = make([]string, len(in.Spec.CachePolicy.CacheKeyPolicy.ExcludedQueryParameters))
 				copy(out.Spec.CachePolicy.CacheKeyPolicy.ExcludedQueryParameters, in.Spec.CachePolicy.CacheKeyPolicy.ExcludedQueryParameters)

--- a/pkg/i2gw/providers/gce/gcphttpfilter.go
+++ b/pkg/i2gw/providers/gce/gcphttpfilter.go
@@ -54,7 +54,7 @@ func (in *GCPHTTPFilter) DeepCopyObject() runtime.Object {
 		if in.Spec.CachePolicy.CacheKeyPolicy != nil {
 			out.Spec.CachePolicy.CacheKeyPolicy = new(emittergce.CacheKeyPolicy)
 			*out.Spec.CachePolicy.CacheKeyPolicy = *in.Spec.CachePolicy.CacheKeyPolicy
-			
+
 			if in.Spec.CachePolicy.CacheKeyPolicy.ExcludedQueryParameters != nil {
 				out.Spec.CachePolicy.CacheKeyPolicy.ExcludedQueryParameters = make([]string, len(in.Spec.CachePolicy.CacheKeyPolicy.ExcludedQueryParameters))
 				copy(out.Spec.CachePolicy.CacheKeyPolicy.ExcludedQueryParameters, in.Spec.CachePolicy.CacheKeyPolicy.ExcludedQueryParameters)

--- a/pkg/i2gw/providers/gce/gcphttpfilter_test.go
+++ b/pkg/i2gw/providers/gce/gcphttpfilter_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gce
+
+import (
+	"reflect"
+	"testing"
+
+	emittergce "github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw/emitter_intermediate/gce"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestGCPHTTPFilter_DeepCopyObject(t *testing.T) {
+	boolPtr := func(b bool) *bool { return &b }
+
+	filter := &GCPHTTPFilter{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-filter",
+			Labels: map[string]string{
+				"key": "value",
+			},
+		},
+		Spec: GCPHTTPFilterSpec{
+			CachePolicy: &emittergce.CachePolicy{
+				CacheMode:         "CACHE_ALL_STATIC",
+				RequestCoalescing: boolPtr(true),
+				CacheKeyPolicy: &emittergce.CacheKeyPolicy{
+					IncludeHost:             boolPtr(true),
+					ExcludedQueryParameters: []string{"q1"},
+				},
+				NegativeCachingPolicy: []emittergce.NegativeCachingPolicy{
+					{Code: 404, TTL: "300s"},
+				},
+				CacheBypassRequestHeaderNames: []string{"x-bypass"},
+			},
+		},
+	}
+
+	copyObj := filter.DeepCopyObject()
+	copyFilter, ok := copyObj.(*GCPHTTPFilter)
+	if !ok {
+		t.Fatalf("DeepCopyObject returned type %T, want *GCPHTTPFilter", copyObj)
+	}
+
+	if filter == copyFilter {
+		t.Errorf("DeepCopyObject returned same pointer")
+	}
+
+	if !reflect.DeepEqual(filter, copyFilter) {
+		t.Errorf("DeepCopyObject content not equal: got %#v, want %#v", copyFilter, filter)
+	}
+
+	// Mutate original to verify deep copy
+	filter.ObjectMeta.Labels["key"] = "new-value"
+	if copyFilter.ObjectMeta.Labels["key"] == "new-value" {
+		t.Errorf("ObjectMeta.Labels was shallow copied")
+	}
+
+	filter.Spec.CachePolicy.CacheMode = "NEW_MODE"
+	if copyFilter.Spec.CachePolicy.CacheMode == "NEW_MODE" {
+		t.Errorf("Spec.CachePolicy was shallow copied")
+	}
+
+	filter.Spec.CachePolicy.CacheKeyPolicy.ExcludedQueryParameters[0] = "mutated"
+	if copyFilter.Spec.CachePolicy.CacheKeyPolicy.ExcludedQueryParameters[0] == "mutated" {
+		t.Errorf("CacheKeyPolicy.ExcludedQueryParameters was shallow copied")
+	}
+
+	filter.Spec.CachePolicy.NegativeCachingPolicy[0].Code = 500
+	if copyFilter.Spec.CachePolicy.NegativeCachingPolicy[0].Code == 500 {
+		t.Errorf("Spec.CachePolicy.NegativeCachingPolicy was shallow copied")
+	}
+
+	filter.Spec.CachePolicy.CacheBypassRequestHeaderNames[0] = "mutated"
+	if copyFilter.Spec.CachePolicy.CacheBypassRequestHeaderNames[0] == "mutated" {
+		t.Errorf("Spec.CachePolicy.CacheBypassRequestHeaderNames was shallow copied")
+	}
+}

--- a/pkg/i2gw/providers/gce/gcphttpfilter_test.go
+++ b/pkg/i2gw/providers/gce/gcphttpfilter_test.go
@@ -75,6 +75,11 @@ func TestGCPHTTPFilter_DeepCopyObject(t *testing.T) {
 		t.Errorf("Spec.CachePolicy was shallow copied")
 	}
 
+	*filter.Spec.CachePolicy.CacheKeyPolicy.IncludeHost = false
+	if *copyFilter.Spec.CachePolicy.CacheKeyPolicy.IncludeHost == false {
+		t.Errorf("CacheKeyPolicy.IncludeHost was shallow copied")
+	}
+
 	filter.Spec.CachePolicy.CacheKeyPolicy.ExcludedQueryParameters[0] = "mutated"
 	if copyFilter.Spec.CachePolicy.CacheKeyPolicy.ExcludedQueryParameters[0] == "mutated" {
 		t.Errorf("CacheKeyPolicy.ExcludedQueryParameters was shallow copied")

--- a/pkg/i2gw/providers/gce/ir_converter.go
+++ b/pkg/i2gw/providers/gce/ir_converter.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	backendconfigv1 "k8s.io/ingress-gce/pkg/apis/backendconfig/v1"
 	frontendconfigv1beta1 "k8s.io/ingress-gce/pkg/apis/frontendconfig/v1beta1"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 type contextKey int
@@ -98,6 +99,7 @@ func (c *resourcesToIRConverter) convertToIR(storage *storage) (providerir.Provi
 	}
 	buildGceGatewayIR(c.ctx, storage, &ir)
 	buildGceServiceIR(c.ctx, c.notify, storage, &ir)
+	patchGceHTTPRouteIR(&ir)
 	return ir, errs
 }
 
@@ -282,6 +284,63 @@ func beConfigToGceServiceIR(beConfig *backendconfigv1.BackendConfig) gce.Service
 	if beConfig.Spec.HealthCheck != nil {
 		gceServiceIR.HealthCheck = extensions.BuildIRHealthCheckConfig(beConfig)
 	}
+	if beConfig.Spec.Cdn != nil {
+		gceServiceIR.Cdn = extensions.BuildIRCdnConfig(beConfig)
+	}
 
 	return gceServiceIR
+}
+
+func patchGceHTTPRouteIR(ir *providerir.ProviderIR) {
+	for routeKey, routeCtx := range ir.HTTPRoutes {
+		for i := range routeCtx.Spec.Rules {
+			for j := range routeCtx.Spec.Rules[i].BackendRefs {
+				if len(routeCtx.RuleBackendSources) <= i || len(routeCtx.RuleBackendSources[i]) <= j {
+					continue
+				}
+				bs := routeCtx.RuleBackendSources[i][j]
+				var serviceName string
+				if bs.Path != nil && bs.Path.Backend.Service != nil {
+					serviceName = bs.Path.Backend.Service.Name
+				} else if bs.DefaultBackend != nil && bs.DefaultBackend.Service != nil {
+					serviceName = bs.DefaultBackend.Service.Name
+				}
+				if serviceName == "" {
+					continue
+				}
+				svcKey := types.NamespacedName{Namespace: routeKey.Namespace, Name: serviceName}
+				serviceIR, exists := ir.Services[svcKey]
+				if !exists || serviceIR.Gce == nil || serviceIR.Gce.Cdn == nil {
+					continue
+				}
+				// Found a backend with CDN enabled!
+				// Attach the filter to the HTTPRoute rule.
+				filter := gatewayv1.HTTPRouteFilter{
+					Type: gatewayv1.HTTPRouteFilterExtensionRef,
+					ExtensionRef: &gatewayv1.LocalObjectReference{
+						Group: "networking.gke.io",
+						Kind:  "GCPHTTPFilter",
+						Name:  gatewayv1.ObjectName(serviceName),
+					},
+				}
+				if routeCtx.Spec.Rules[i].Filters == nil {
+					routeCtx.Spec.Rules[i].Filters = make([]gatewayv1.HTTPRouteFilter, 0)
+				}
+				// Avoid adding duplicate filters
+				alreadyExists := false
+				for _, existingFilter := range routeCtx.Spec.Rules[i].Filters {
+					if existingFilter.Type == gatewayv1.HTTPRouteFilterExtensionRef &&
+						existingFilter.ExtensionRef != nil &&
+						existingFilter.ExtensionRef.Name == filter.ExtensionRef.Name {
+						alreadyExists = true
+						break
+					}
+				}
+				if !alreadyExists {
+					routeCtx.Spec.Rules[i].Filters = append(routeCtx.Spec.Rules[i].Filters, filter)
+				}
+			}
+		}
+		ir.HTTPRoutes[routeKey] = routeCtx
+	}
 }

--- a/pkg/i2gw/providers/gce/ir_converter.go
+++ b/pkg/i2gw/providers/gce/ir_converter.go
@@ -320,7 +320,7 @@ func patchGceHTTPRouteIR(ir *providerir.ProviderIR) {
 					ExtensionRef: &gatewayv1.LocalObjectReference{
 						Group: "networking.gke.io",
 						Kind:  "GCPHTTPFilter",
-						Name:  gatewayv1.ObjectName(serviceName),
+						Name:  gatewayv1.ObjectName(serviceName + "-filter"),
 					},
 				}
 				if routeCtx.Spec.Rules[i].Filters == nil {

--- a/pkg/i2gw/providers/gce/ir_converter.go
+++ b/pkg/i2gw/providers/gce/ir_converter.go
@@ -33,7 +33,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	backendconfigv1 "k8s.io/ingress-gce/pkg/apis/backendconfig/v1"
 	frontendconfigv1beta1 "k8s.io/ingress-gce/pkg/apis/frontendconfig/v1beta1"
-	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 type contextKey int
@@ -99,7 +98,6 @@ func (c *resourcesToIRConverter) convertToIR(storage *storage) (providerir.Provi
 	}
 	buildGceGatewayIR(c.ctx, storage, &ir)
 	buildGceServiceIR(c.ctx, c.notify, storage, &ir)
-	patchGceHTTPRouteIR(&ir)
 	return ir, errs
 }
 
@@ -289,58 +287,4 @@ func beConfigToGceServiceIR(beConfig *backendconfigv1.BackendConfig) gce.Service
 	}
 
 	return gceServiceIR
-}
-
-func patchGceHTTPRouteIR(ir *providerir.ProviderIR) {
-	for routeKey, routeCtx := range ir.HTTPRoutes {
-		for i := range routeCtx.Spec.Rules {
-			for j := range routeCtx.Spec.Rules[i].BackendRefs {
-				if len(routeCtx.RuleBackendSources) <= i || len(routeCtx.RuleBackendSources[i]) <= j {
-					continue
-				}
-				bs := routeCtx.RuleBackendSources[i][j]
-				var serviceName string
-				if bs.Path != nil && bs.Path.Backend.Service != nil {
-					serviceName = bs.Path.Backend.Service.Name
-				} else if bs.DefaultBackend != nil && bs.DefaultBackend.Service != nil {
-					serviceName = bs.DefaultBackend.Service.Name
-				}
-				if serviceName == "" {
-					continue
-				}
-				svcKey := types.NamespacedName{Namespace: routeKey.Namespace, Name: serviceName}
-				serviceIR, exists := ir.Services[svcKey]
-				if !exists || serviceIR.Gce == nil || serviceIR.Gce.Cdn == nil {
-					continue
-				}
-				// Found a backend with CDN enabled!
-				// Attach the filter to the HTTPRoute rule.
-				filter := gatewayv1.HTTPRouteFilter{
-					Type: gatewayv1.HTTPRouteFilterExtensionRef,
-					ExtensionRef: &gatewayv1.LocalObjectReference{
-						Group: "networking.gke.io",
-						Kind:  "GCPHTTPFilter",
-						Name:  gatewayv1.ObjectName(serviceName + "-filter"),
-					},
-				}
-				if routeCtx.Spec.Rules[i].Filters == nil {
-					routeCtx.Spec.Rules[i].Filters = make([]gatewayv1.HTTPRouteFilter, 0)
-				}
-				// Avoid adding duplicate filters
-				alreadyExists := false
-				for _, existingFilter := range routeCtx.Spec.Rules[i].Filters {
-					if existingFilter.Type == gatewayv1.HTTPRouteFilterExtensionRef &&
-						existingFilter.ExtensionRef != nil &&
-						existingFilter.ExtensionRef.Name == filter.ExtensionRef.Name {
-						alreadyExists = true
-						break
-					}
-				}
-				if !alreadyExists {
-					routeCtx.Spec.Rules[i].Filters = append(routeCtx.Spec.Rules[i].Filters, filter)
-				}
-			}
-		}
-		ir.HTTPRoutes[routeKey] = routeCtx
-	}
 }

--- a/pkg/i2gw/providers/gce/ir_converter_test.go
+++ b/pkg/i2gw/providers/gce/ir_converter_test.go
@@ -1055,7 +1055,7 @@ func Test_convertToIR(t *testing.T) {
 												ExtensionRef: &gatewayv1.LocalObjectReference{
 													Group: "networking.gke.io",
 													Kind:  "GCPHTTPFilter",
-													Name:  "test-service",
+													Name:  "test-service-filter",
 												},
 											},
 										},

--- a/pkg/i2gw/providers/gce/ir_converter_test.go
+++ b/pkg/i2gw/providers/gce/ir_converter_test.go
@@ -976,6 +976,115 @@ func Test_convertToIR(t *testing.T) {
 			},
 			expectedErrors: field.ErrorList{},
 		},
+		{
+			name: "ingress with a Backend Config specifying Cloud CDN",
+			modify: func(storage *storage) {
+				testService := storage.Services[types.NamespacedName{Namespace: testNamespace, Name: testServiceName}]
+				testService.Annotations = map[string]string{
+					backendConfigKey: `{"default":"test-backendconfig"}`,
+				}
+				storage.Services[types.NamespacedName{Namespace: testNamespace, Name: testServiceName}] = testService
+
+				beConfigSpec := backendconfigv1.BackendConfigSpec{
+					Cdn: &backendconfigv1.CDNConfig{
+						CacheMode:         common.PtrTo("USE_ORIGIN_HEADERS"),
+						DefaultTtl:        common.PtrTo(int64(3600)),
+						MaxTtl:            common.PtrTo(int64(7200)),
+						ClientTtl:         common.PtrTo(int64(1800)),
+						RequestCoalescing: common.PtrTo(true),
+						ServeWhileStale:   common.PtrTo(int64(86400)),
+						NegativeCaching:   common.PtrTo(true),
+					},
+				}
+				storage.BackendConfigs = map[types.NamespacedName]*backendconfigv1.BackendConfig{
+					{Namespace: testNamespace, Name: testBackendConfigName}: getTestBackendConfig(beConfigSpec),
+				}
+			},
+			expectedIR: providerir.ProviderIR{
+				Gateways: map[types.NamespacedName]providerir.GatewayContext{
+					{Namespace: testNamespace, Name: gceIngressClass}: {
+						Gateway: gatewayv1.Gateway{
+							ObjectMeta: metav1.ObjectMeta{Name: gceIngressClass, Namespace: testNamespace},
+							Spec: gatewayv1.GatewaySpec{
+								GatewayClassName: gceL7GlobalExternalManagedGatewayClass,
+								Listeners: []gatewayv1.Listener{{
+									Name:     "test-mydomain-com-http",
+									Port:     80,
+									Protocol: gatewayv1.HTTPProtocolType,
+									Hostname: common.PtrTo(gatewayv1.Hostname(testHost)),
+								}},
+							},
+						},
+					},
+				},
+				HTTPRoutes: map[types.NamespacedName]providerir.HTTPRouteContext{
+					{Namespace: testNamespace, Name: fmt.Sprintf("%s-test-mydomain-com", testIngressName)}: {
+						HTTPRoute: gatewayv1.HTTPRoute{
+							ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s-test-mydomain-com", testIngressName), Namespace: testNamespace},
+							Spec: gatewayv1.HTTPRouteSpec{
+								CommonRouteSpec: gatewayv1.CommonRouteSpec{
+									ParentRefs: []gatewayv1.ParentReference{{
+										Name: gceIngressClass,
+									}},
+								},
+								Hostnames: []gatewayv1.Hostname{gatewayv1.Hostname(testHost)},
+								Rules: []gatewayv1.HTTPRouteRule{
+									{
+										Name: common.PtrTo(gatewayv1.SectionName("rule-0")),
+										Matches: []gatewayv1.HTTPRouteMatch{
+											{
+												Path: &gatewayv1.HTTPPathMatch{
+													Type:  common.PtrTo(gPathPrefix),
+													Value: common.PtrTo("/"),
+												},
+											},
+										},
+										BackendRefs: []gatewayv1.HTTPBackendRef{
+											{
+												BackendRef: gatewayv1.BackendRef{
+													BackendObjectReference: gatewayv1.BackendObjectReference{
+														Name: gatewayv1.ObjectName(testServiceName),
+														Port: common.PtrTo(gatewayv1.PortNumber(80)),
+													},
+												},
+											},
+										},
+										Filters: []gatewayv1.HTTPRouteFilter{
+											{
+												Type: gatewayv1.HTTPRouteFilterExtensionRef,
+												ExtensionRef: &gatewayv1.LocalObjectReference{
+													Group: "networking.gke.io",
+													Kind:  "GCPHTTPFilter",
+													Name:  "test-service",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Services: map[types.NamespacedName]providerir.ProviderSpecificServiceIR{
+					{Namespace: testNamespace, Name: testServiceName}: {
+						Gce: &gce.ServiceIR{
+							Cdn: &gce.CdnConfig{
+								CachePolicy: &gce.CachePolicy{
+									CacheMode:         "USE_ORIGIN_HEADERS",
+									DefaultTTL:        "3600s",
+									MaxTTL:            "7200s",
+									ClientTTL:         "1800s",
+									RequestCoalescing: common.PtrTo(true),
+									ServeWhileStale:   "86400s",
+									NegativeCaching:   common.PtrTo(true),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedErrors: field.ErrorList{},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/i2gw/providers/gce/ir_converter_test.go
+++ b/pkg/i2gw/providers/gce/ir_converter_test.go
@@ -1049,16 +1049,6 @@ func Test_convertToIR(t *testing.T) {
 												},
 											},
 										},
-										Filters: []gatewayv1.HTTPRouteFilter{
-											{
-												Type: gatewayv1.HTTPRouteFilterExtensionRef,
-												ExtensionRef: &gatewayv1.LocalObjectReference{
-													Group: "networking.gke.io",
-													Kind:  "GCPHTTPFilter",
-													Name:  "test-service-filter",
-												},
-											},
-										},
 									},
 								},
 							},

--- a/pkg/i2gw/providers/gce/ir_converter_test.go
+++ b/pkg/i2gw/providers/gce/ir_converter_test.go
@@ -1437,5 +1437,3 @@ func TestGetBackendConfigName(t *testing.T) {
 		})
 	}
 }
-
-

--- a/pkg/i2gw/providers/gce/ir_converter_test.go
+++ b/pkg/i2gw/providers/gce/ir_converter_test.go
@@ -1121,6 +1121,15 @@ func Test_convertToIR(t *testing.T) {
 					key := types.NamespacedName{Namespace: gotHTTPRouteContext.HTTPRoute.Namespace, Name: gotHTTPRouteContext.HTTPRoute.Name}
 					wantHTTPRouteContext := tc.expectedIR.HTTPRoutes[key]
 					wantHTTPRouteContext.HTTPRoute.SetGroupVersionKind(common.HTTPRouteGVK)
+					for j := range gotHTTPRouteContext.HTTPRoute.Spec.Rules {
+						gotHTTPRouteContext.HTTPRoute.Spec.Rules[j].Name = nil
+					}
+					gotHTTPRouteContext.HTTPRoute.Status = gatewayv1.HTTPRouteStatus{}
+					for j := range wantHTTPRouteContext.HTTPRoute.Spec.Rules {
+						wantHTTPRouteContext.HTTPRoute.Spec.Rules[j].Name = nil
+					}
+					wantHTTPRouteContext.HTTPRoute.Status = gatewayv1.HTTPRouteStatus{}
+
 					if !apiequality.Semantic.DeepEqual(gotHTTPRouteContext.HTTPRoute, wantHTTPRouteContext.HTTPRoute) {
 						t.Errorf("Expected HTTPRoute %s to be %+v\n Got: %+v\n Diff: %s", i, wantHTTPRouteContext.HTTPRoute, gotHTTPRouteContext.HTTPRoute, cmp.Diff(wantHTTPRouteContext.HTTPRoute, gotHTTPRouteContext.HTTPRoute))
 					}

--- a/pkg/i2gw/providers/gce/ir_converter_test.go
+++ b/pkg/i2gw/providers/gce/ir_converter_test.go
@@ -1437,3 +1437,5 @@ func TestGetBackendConfigName(t *testing.T) {
 		})
 	}
 }
+
+

--- a/pkg/i2gw/providers/gce/ir_converter_test.go
+++ b/pkg/i2gw/providers/gce/ir_converter_test.go
@@ -1053,6 +1053,11 @@ func Test_convertToIR(t *testing.T) {
 									},
 								},
 							},
+							Status: gatewayv1.HTTPRouteStatus{
+								RouteStatus: gatewayv1.RouteStatus{
+									Parents: []gatewayv1.RouteParentStatus{},
+								},
+							},
 						},
 					},
 				},

--- a/pkg/i2gw/providers/gce/ir_converter_test.go
+++ b/pkg/i2gw/providers/gce/ir_converter_test.go
@@ -987,6 +987,7 @@ func Test_convertToIR(t *testing.T) {
 
 				beConfigSpec := backendconfigv1.BackendConfigSpec{
 					Cdn: &backendconfigv1.CDNConfig{
+						Enabled:           true,
 						CacheMode:         common.PtrTo("USE_ORIGIN_HEADERS"),
 						DefaultTtl:        common.PtrTo(int64(3600)),
 						MaxTtl:            common.PtrTo(int64(7200)),

--- a/pkg/i2gw/providers/gce/ir_converter_test.go
+++ b/pkg/i2gw/providers/gce/ir_converter_test.go
@@ -1031,7 +1031,6 @@ func Test_convertToIR(t *testing.T) {
 								Hostnames: []gatewayv1.Hostname{gatewayv1.Hostname(testHost)},
 								Rules: []gatewayv1.HTTPRouteRule{
 									{
-										Name: common.PtrTo(gatewayv1.SectionName("rule-0")),
 										Matches: []gatewayv1.HTTPRouteMatch{
 											{
 												Path: &gatewayv1.HTTPPathMatch{
@@ -1053,11 +1052,7 @@ func Test_convertToIR(t *testing.T) {
 									},
 								},
 							},
-							Status: gatewayv1.HTTPRouteStatus{
-								RouteStatus: gatewayv1.RouteStatus{
-									Parents: []gatewayv1.RouteParentStatus{},
-								},
-							},
+							Status: gatewayv1.HTTPRouteStatus{},
 						},
 					},
 				},


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:


This PR adds support for translating Cloud CDN configurations from GKE Ingress (via BackendConfig) to GKE Gateway (via GCPHTTPFilter).

Key additions:

- Maps BackendConfig CDN settings to the GCE intermediate representation (ServiceIR).
- Performs a post-processing step to attach GCPHTTPFilter as an ExtensionRef filter on relevant HTTPRoute rules.
- Emits the required GCPHTTPFilter custom resources.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Added Cloud CDN support for GCE provider, translating BackendConfig CDN settings to GKE Gateway GCPHTTPFilter resources.
```
