### PR TITLE
feat(notifications): adds Report.Notifications() accessor grouped by source

### DIFF
--- a/pkg/i2gw/notifications/report.go
+++ b/pkg/i2gw/notifications/report.go
@@ -107,14 +107,12 @@ func (r *Report) Notifier(source string) NotifyFunc {
 // after conversion completes. Notifications are sorted by source name for deterministic output.
 // Returns "" when r is nil or there are no notifications.
 func (r *Report) Render() string {
-	if r == nil {
+	notifications := r.Notifications()
+	if len(notifications) == 0 {
 		return ""
 	}
 
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	sources := slices.Sorted(maps.Keys(r.notifications))
+	sources := slices.Sorted(maps.Keys(notifications))
 
 	// Returns the ANSI code, or "" when color is disabled.
 	c := func(code string) string {
@@ -127,7 +125,7 @@ func (r *Report) Render() string {
 	var buf strings.Builder
 
 	for _, source := range sources {
-		for _, n := range r.notifications[source] {
+		for _, n := range notifications[source] {
 			label, lcolor := levelLabel(n.Type)
 
 			// Top border with level.

--- a/pkg/i2gw/notifications/report.go
+++ b/pkg/i2gw/notifications/report.go
@@ -68,6 +68,29 @@ func (r *Report) Add(source string, n Notification) {
 	r.mu.Unlock()
 }
 
+func (r *Report) Notifications() map[string][]Notification {
+	if r == nil {
+		return nil
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if len(r.notifications) == 0 {
+		return nil
+	}
+
+	out := make(map[string][]Notification, len(r.notifications))
+	for source, ns := range r.notifications {
+		cloned := slices.Clone(ns)
+		for i := range cloned {
+			cloned[i].CallingObjects = slices.Clone(cloned[i].CallingObjects)
+		}
+		out[source] = cloned
+	}
+	return out
+}
+
 // Notifier returns a convenience function scoped to a single source name, eliminating the need for
 // per-package boilerplate.
 func (r *Report) Notifier(source string) NotifyFunc {

--- a/pkg/i2gw/notifications/report_test.go
+++ b/pkg/i2gw/notifications/report_test.go
@@ -167,6 +167,11 @@ func TestReportConcurrentAdd(t *testing.T) {
 			_ = r.Render()
 		}
 	})
+	wg.Go(func() {
+		for range 100 {
+			_ = r.Notifications()
+		}
+	})
 
 	wg.Wait()
 
@@ -175,6 +180,65 @@ func TestReportConcurrentAdd(t *testing.T) {
 	for _, provider := range providers {
 		assert.Equal(t, 100, strings.Count(result, "source: "+strings.ToUpper(provider)))
 	}
+
+	m := r.Notifications()
+	for _, provider := range providers {
+		assert.Len(t, m[provider], 100)
+	}
+}
+
+func TestReportNotifications(t *testing.T) {
+	t.Run("nil report returns nil", func(t *testing.T) {
+		var r *Report
+		assert.Nil(t, r.Notifications())
+	})
+
+	t.Run("empty report returns nil", func(t *testing.T) {
+		r := NewReport(true)
+		assert.Nil(t, r.Notifications())
+	})
+
+	t.Run("grouped by source", func(t *testing.T) {
+		r := NewReport(true)
+		r.Add("kong", Notification{Type: WarningNotification, Message: "kong-1"})
+		r.Add("istio", Notification{Type: InfoNotification, Message: "istio-1"})
+		r.Add("istio", Notification{Type: ErrorNotification, Message: "istio-2"})
+		r.Add("kong", Notification{Type: InfoNotification, Message: "kong-2"})
+
+		assert.Equal(t, map[string][]Notification{
+			"istio": {
+				{Type: InfoNotification, Message: "istio-1"},
+				{Type: ErrorNotification, Message: "istio-2"},
+			},
+			"kong": {
+				{Type: WarningNotification, Message: "kong-1"},
+				{Type: InfoNotification, Message: "kong-2"},
+			},
+		}, r.Notifications())
+	})
+
+	t.Run("returned map is a defensive copy of the report state", func(t *testing.T) {
+		ingress := &networkingv1.Ingress{
+			TypeMeta:   metav1.TypeMeta{Kind: "Ingress"},
+			ObjectMeta: metav1.ObjectMeta{Name: "ing", Namespace: "default"},
+		}
+		r := NewReport(true)
+		r.Add("p", Notification{Message: "first", CallingObjects: []client.Object{ingress}})
+
+		m := r.Notifications()
+		delete(m, "p")
+		m["evil"] = []Notification{{Message: "injected"}}
+
+		m2 := r.Notifications()
+		m2["p"][0].Message = "mutated"
+		m2["p"][0].CallingObjects[0] = nil
+
+		final := r.Notifications()
+		assert.Len(t, final, 1)
+		assert.NotContains(t, final, "evil")
+		assert.Equal(t, "first", final["p"][0].Message)
+		assert.Same(t, ingress, final["p"][0].CallingObjects[0])
+	})
 }
 
 func TestReportNotifier(t *testing.T) {


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/ingress2gateway/blob/main/CONTRIBUTING.md). -->

<!-- The release notes and the kind will be used to generate the Changelog for the release. To make sure your contribution is recognized, please label this pull request according to what type of issue you are addressing and add the release notes when necessary (see ../CONTRIBUTING.md) -->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**: 

Adds `notifications.Report.Notifications()`. 

Currently the only way to read notifications off a Report is `Render()`, which returns a human-formatted string for CLI use. Go programs importing ingress2gateway as a module (calling `provider.ToIR()` or `i2gw.ToGatewayAPIResources()` directly) have no way to inspect notifications without parsing that string.

The accessor returns a defensive copy and is safe to call concurrently with Add. No changes to existing public API; `Render()` output is unchanged.

An alternative was to add a `Source` field to `Notification` itself for flat iteration, but that left `Add(source, n)` with two ways to set the source -- fixing that cleanly would have meant unexporting `Add` and forcing all producers through `Notifier(source)`. The grouped map keeps `Notification` source-agnostic and avoids the question.

**Which issue(s) this PR fixes**:
N/A

**Does this PR introduce a user-facing change?**:
No CLI-facing changes. Open to feedback on whether changes to the Go API surface warrant a release note.
